### PR TITLE
doc: Use `getpass` instead of inline passphrase.

### DIFF
--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -113,7 +113,8 @@ class Account(object):
              'id': 'b812f3f9-78cc-462a-9e89-74418aa27cb0',
              'version': 3}
 
-            >>> Account.decrypt(encrypted, 'correcthorsebatterystaple')
+            >>> import getpass
+            >>> Account.decrypt(encrypted, getpass.getpass())
             HexBytes('0xb25c7db31feed9122727bf0939dc769a96564b2de4c4726d035b36ecf1e5b364')
 
         '''
@@ -142,9 +143,10 @@ class Account(object):
 
         .. code-block:: python
 
+            >>> import getpass
             >>> encrypted = Account.encrypt(
                 0xb25c7db31feed9122727bf0939dc769a96564b2de4c4726d035b36ecf1e5b364,
-                'correcthorsebatterystaple'
+                getpass.getpass()
             )
 
             {'address': '5ce9454909639d2d17a3f753ce7d93fa0b9ab12e',


### PR DESCRIPTION
## What was wrong?

Documentation shows passphrase in cleartext.

## How was it fixed?

Provide a quick hint (`getpass.getpass()`) on how this can be avoided.

(Since the examples show a REPL, IMO it's fine using an interactive prompt.)

#### Cute Animal Picture

> "You what in there?.."

![lemur with wide-open eyes](https://camo.githubusercontent.com/6b61966af8919a1d14490664e144fa208cc286e7/68747470733a2f2f7777772e6c65657362757267616e696d616c7061726b2e636f6d2f77702d636f6e74656e742f75706c6f6164732f323031362f30392f6c656d75722e6a7067)

Source: [Leesburg animal park](https://www.leesburganimalpark.com/meet-the-animals/)