### PR TITLE
require checksum on 'to' address in transaction

### DIFF
--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -459,6 +459,7 @@ class Account(object):
         .. code-block:: python
 
             >>> transaction = {
+                    # Note that the address must be in checksum format:
                     'to': '0xF0109fC8DF283027b6285cc889F5aA624EaC1F55',
                     'value': 1000000000,
                     'gas': 2000000,

--- a/eth_account/transactions.py
+++ b/eth_account/transactions.py
@@ -16,8 +16,8 @@ from eth_utils.curried import (
     apply_one_of_formatters,
     hexstr_if_str,
     is_0x_prefixed,
-    is_address,
     is_bytes,
+    is_checksum_address,
     is_integer,
     is_string,
     to_bytes,
@@ -63,10 +63,10 @@ def is_int_or_prefixed_hexstr(val):
         return False
 
 
-def is_empty_or_address(val):
+def is_empty_or_checksum_address(val):
     if val in {None, b'', ''}:
         return True
-    elif is_address(val):
+    elif is_checksum_address(val):
         return True
     else:
         return False
@@ -102,7 +102,7 @@ TRANSACTION_VALID_VALUES = {
     'nonce': is_int_or_prefixed_hexstr,
     'gasPrice': is_int_or_prefixed_hexstr,
     'gas': is_int_or_prefixed_hexstr,
-    'to': is_empty_or_address,
+    'to': is_empty_or_checksum_address,
     'value': is_int_or_prefixed_hexstr,
     'data': lambda val: isinstance(val, (int, str, bytes, bytearray)),
     'chainId': lambda val: val is None or is_int_or_prefixed_hexstr(val),

--- a/tests/core/test_accounts.py
+++ b/tests/core/test_accounts.py
@@ -27,7 +27,7 @@ ETH_TEST_TRANSACTIONS = [
         "nonce": 0,
         "gasPrice": 1000000000000,
         "gas": 10000,
-        "to": "13978aee95f38490e9769c39b2773ed763d9cd5f",
+        "to": "0x13978aee95f38490e9769C39B2773Ed763d9cd5F",
         "value": 10000000000000000,
         "data": "",
         "unsigned": "eb8085e8d4a510008227109413978aee95f38490e9769c39b2773ed763d9cd5f872386f26fc1000080808080",  # noqa: 501

--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -15,6 +15,8 @@ GOOD_TXN = {
     'nonce': 3,
 }
 
+TEST_PRIVATE_KEY = b'\0' * 32
+
 
 @pytest.mark.parametrize(
     'txn_dict, bad_fields',
@@ -22,14 +24,14 @@ GOOD_TXN = {
         (dict(GOOD_TXN), {}),
         (dict(GOOD_TXN, to=None), {}),
         (dict(GOOD_TXN, to=b''), {}),
-        (dict(GOOD_TXN, to=b'\0' * 20), {}),
-        (dict(GOOD_TXN, to=b'\0' * 19), {'to'}),
-        (dict(GOOD_TXN, to=b'\0' * 21), {'to'}),
         (dict(GOOD_TXN, to='0x' + '00' * 20), {}),
+        (dict(GOOD_TXN, to='0xF0109fC8DF283027b6285cc889F5aA624EaC1F55'), {}),
+        (dict(GOOD_TXN, to='0xf0109Fc8df283027B6285CC889f5Aa624eAc1f55'), {'to'}),
         pytest.mark.xfail(reason="eth-utils accepts 19-byte hex address as address")(
             (dict(GOOD_TXN, to='0x' + '00' * 19), {'to'})
         ),
         (dict(GOOD_TXN, to='0x' + '00' * 21), {'to'}),
+        (dict(GOOD_TXN, to=b'\0' * 20), {'to'}),
         (dict(GOOD_TXN, gas='0e1'), {'gas'}),
         (dict(GOOD_TXN, gasPrice='0e1'), {'gasPrice'}),
         (dict(GOOD_TXN, value='0e1'), {'value'}),
@@ -54,9 +56,9 @@ GOOD_TXN = {
 )
 def test_invalid_transaction_fields(txn_dict, bad_fields):
     if not bad_fields:
-        Account.signTransaction(txn_dict, b'\0' * 32)
+        Account.signTransaction(txn_dict, TEST_PRIVATE_KEY)
     else:
         with pytest.raises(TypeError) as excinfo:
-            Account.signTransaction(txn_dict, b'\0' * 32)
+            Account.signTransaction(txn_dict, TEST_PRIVATE_KEY)
         for field in bad_fields:
             assert field in str(excinfo.value)


### PR DESCRIPTION
## What was wrong?

Closes #1

## How was it fixed?

Check for valid checksum address before signing transaction. Add a couple tests to verify.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/9oBrE5DRLVY/maxresdefault.jpg)
