### PR TITLE
Drop chainId as a required field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,8 @@ output/*/index.html
 # Sphinx
 docs/_build
 docs/modules.rst
-docs/web3.*
+docs/*.internal.rst
+docs/*.utils.rst
 
 # Blockchain
 chains

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -1,6 +1,15 @@
 Release Notes
 =============
 
+v0.2.0 (stable)
+----------------
+
+Released Apr 19, 2018
+
+- Audit cleanup is complete
+- Stopped requiring chainId, until tooling to automatically derive it gets better
+  (Not that transactions without chainId are potentially replayable on fork chains)
+
 v0.2.0-alpha.0
 --------------
 

--- a/eth_account/datastructures.py
+++ b/eth_account/datastructures.py
@@ -24,5 +24,5 @@ class AttributeDict(AttrDict):
         if cycle:
             builder.text("<cycle>")
         else:
-            builder.pretty(self.__dict__)
+            builder.pretty(dict(self))
         builder.text(")")

--- a/eth_account/internal/transactions.py
+++ b/eth_account/internal/transactions.py
@@ -80,6 +80,7 @@ TRANSACTION_DEFAULTS = {
     'to': b'',
     'value': 0,
     'data': b'',
+    'chainId': None,
 }
 
 TRANSACTION_FORMATTERS = {

--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -9,7 +9,6 @@ from eth_account import (
 )
 
 GOOD_TXN = {
-    'chainId': 1,
     'gasPrice': 2,
     'gas': 200000,
     'nonce': 3,
@@ -46,7 +45,6 @@ TEST_PRIVATE_KEY = b'\0' * 32
         (dict(GOOD_TXN, gasprice=1), {'gasprice'}),
 
         # missing keys will be called out explicitly
-        (dissoc(GOOD_TXN, 'chainId'), {'chainId'}),
         (dissoc(GOOD_TXN, 'gasPrice'), {'gasPrice'}),
         (dissoc(GOOD_TXN, 'gas'), {'gas'}),
         (dissoc(GOOD_TXN, 'nonce'), {'nonce'}),


### PR DESCRIPTION
## What was wrong?

`chainId` is too difficult to get programmatically right now, so it's a big burden to require it when signing transactions.

## How was it fixed?

Drop `chainId` as a hard requirement for creating transactions. This has the side effect of creating replayable transactions by default. The reality is that this is not a huge concern for most people, and the people who do care can still choose to specify `chainId` to make it non-replayable.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://thenypost.files.wordpress.com/2017/09/170918-sea-horse-garbage-feature.jpg?quality=90&strip=all&w=618&h=410&crop=1)