### PR TITLE
Update for rlp 1.0.0

### DIFF
--- a/eth_account/internal/transactions.py
+++ b/eth_account/internal/transactions.py
@@ -168,7 +168,15 @@ class Transaction(HashableRLP):
     )
 
 
-UnsignedTransaction = Transaction.exclude(['v', 'r', 's'])
+class UnsignedTransaction(HashableRLP):
+    fields = (
+        ('nonce', big_endian_int),
+        ('gasPrice', big_endian_int),
+        ('gas', big_endian_int),
+        ('to', Binary.fixed_length(20, allow_empty=True)),
+        ('value', big_endian_int),
+        ('data', binary),
+    )
 
 
 ChainAwareUnsignedTransaction = Transaction


### PR DESCRIPTION
## What was wrong?

Updating to be compatible with the latest `rlp==1.0.0`

## How was it fixed?

Removed use of `exclude` API.

#### Cute Animal Picture

![baby-camel-face](https://user-images.githubusercontent.com/824194/39157123-9a5691e0-4716-11e8-8fb9-c25297b1fffb.jpg)
