### PR TITLE
accept a matching from field in signTransaction

### DIFF
--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -1,6 +1,7 @@
 import pytest
 
 from cytoolz import (
+    assoc,
     dissoc,
 )
 
@@ -29,6 +30,12 @@ TEST_PRIVATE_KEY = b'\0' * 32
         (dict(GOOD_TXN, to='0x' + '00' * 19), {'to'}),
         (dict(GOOD_TXN, to='0x' + '00' * 21), {'to'}),
         (dict(GOOD_TXN, to=b'\0' * 20), {'to'}),
+        # from with the right address is allowed
+        (assoc(GOOD_TXN, 'from', '0x3f17f1962B36e491b30A40b2405849e597Ba5FB5'), {}),
+        # from with a non-checksum address is not
+        (assoc(GOOD_TXN, 'from', '0x3f17f1962b36e491b30a40b2405849e597ba5fb5'), {'from'}),
+        # from with the wrong address is not
+        (assoc(GOOD_TXN, 'from', '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf'), {'from'}),
         (dict(GOOD_TXN, gas='0e1'), {'gas'}),
         (dict(GOOD_TXN, gasPrice='0e1'), {'gasPrice'}),
         (dict(GOOD_TXN, value='0e1'), {'value'}),


### PR DESCRIPTION
## What was wrong?

Unsigned transactions passed in with a 'from' field seem like they should be valid, if the field matches the private key's address. But it was raising a validation exception because no 'from' field is ever allowed.

## How was it fixed?

Check if from field matches the key. If so, strip it out of the transaction. Otherwise, raise exception explaining that the fields must match.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://img.buzzfeed.com/buzzfeed-static/static/enhanced/webdr02/2013/6/5/20/enhanced-buzz-24607-1370479625-2.jpg?downsize=715:*&output-format=auto&output-quality=auto)