### PR TITLE
upgrade eth-rlp for pyrlp v1 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,22 @@ common: &common
   working_directory: ~/repo
   steps:
     - checkout
+    - run:
+        name: merge pull request base
+        command: |
+          if [[ -n "${CIRCLE_PR_NUMBER}" ]]; then
+            PR_INFO_URL=https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls/$CIRCLE_PR_NUMBER
+
+            PR_BASE_BRANCH=$(curl -L "$PR_INFO_URL" | python -c 'import json, sys; obj = json.load(sys.stdin); sys.stdout.write(obj["base"]["ref"])')
+            git fetch origin +"$PR_BASE_BRANCH":circleci/pr-base
+
+            # We need these config values or git complains when creating the
+            # merge commit
+            git config --global user.name "Circle CI"
+            git config --global user.email "circleci@example.com"
+
+            git merge --no-edit circleci/pr-base
+          fi
     - restore_cache:
         keys:
           - cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
@@ -14,7 +30,7 @@ common: &common
         command: pip install --user tox
     - run:
         name: run tox
-        command: ~/.local/bin/tox
+        command: ~/.local/bin/tox -r
     - save_cache:
         paths:
           - .tox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,30 +52,51 @@ jobs:
       - image: circleci/python:3.5
         environment:
           TOXENV: lint
-  py35-core:
+  py35-core-rlp0:
     <<: *common
     docker:
       - image: circleci/python:3.5
         environment:
-          TOXENV: py35-core
-  py36-core:
+          TOXENV: py35-core-rlp0
+  py36-core-rlp0:
     <<: *common
     docker:
       - image: circleci/python:3.6
         environment:
-          TOXENV: py36-core
-  pypy3-core:
+          TOXENV: py36-core-rlp0
+  pypy3-core-rlp0:
     <<: *common
     docker:
       - image: pypy
         environment:
-          TOXENV: pypy3-core
+          TOXENV: pypy3-core-rlp0
+  py35-core-rlp1:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35-core-rlp1
+  py36-core-rlp1:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-core-rlp1
+  pypy3-core-rlp1:
+    <<: *common
+    docker:
+      - image: pypy
+        environment:
+          TOXENV: pypy3-core-rlp1
 workflows:
   version: 2
   test:
     jobs:
       - doctest
       - lint
-      - py35-core
-      - py36-core
-      - pypy3-core
+      - py35-core-rlp0
+      - py36-core-rlp0
+      - pypy3-core-rlp0
+      - py35-core-rlp1
+      - py36-core-rlp1
+      - pypy3-core-rlp1

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,19 +14,28 @@ matrix:
       env: TOX_POSARGS="-e doctest"
     # core
     - python: "3.5"
-      env: TOX_POSARGS="-e py35-core"
+      env: TOX_POSARGS="-e py35-core-rlp0"
+    # core
+    - python: "3.5"
+      env: TOX_POSARGS="-e py35-core-rlp1"
     #
     # Python 3.6 testing
     #
     # core
     - python: "3.6"
-      env: TOX_POSARGS="-e py36-core"
+      env: TOX_POSARGS="-e py36-core-rlp0"
+    # core
+    - python: "3.6"
+      env: TOX_POSARGS="-e py36-core-rlp1"
     #
     # pypy3 testing
     #
     # core
     - python: "pypy3.5"
-      env: TOX_POSARGS="-e pypy3-core"
+      env: TOX_POSARGS="-e pypy3-core-rlp0"
+    # core
+    - python: "pypy3.5"
+      env: TOX_POSARGS="-e pypy3-core-rlp1"
 cache:
   - pip: true
 install:

--- a/README.md
+++ b/README.md
@@ -1,16 +1,13 @@
 # eth-account
 
 [![Join the chat at https://gitter.im/ethereum/eth-account](https://badges.gitter.im/ethereum/eth-account.svg)](https://gitter.im/ethereum/eth-account?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
-[![Build Status](https://travis-ci.org/ethereum/eth-account.png)](https://travis-ci.org/ethereum/eth-account)
+[![Build Status](https://circleci.com/gh/ethereum/eth-account.svg?style=shield)](https://circleci.com/gh/ethereum/eth-account)
 [![PyPI version](https://badge.fury.io/py/eth-account.svg)](https://badge.fury.io/py/eth-account)
 [![Python versions](https://img.shields.io/pypi/pyversions/eth-account.svg)](https://pypi.python.org/pypi/eth-account)
 [![Docs build](https://readthedocs.org/projects/eth-account/badge/?version=latest)](http://eth-account.readthedocs.io/en/latest/?badge=latest)
    
 
 Sign Ethereum transactions and messages with local private keys
-
-* Python 3.5+ support
 
 Read more in the [documentation on ReadTheDocs](http://eth-account.readthedocs.io/). [View the change log](http://eth-account.readthedocs.io/en/latest/releases.html)
 

--- a/fill_template_vars.sh
+++ b/fill_template_vars.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "What is your python module name?"
+read MODULE_NAME
+
+echo "What is your pypi package name? (default: $MODULE_NAME)"
+read PYPI_INPUT
+PYPI_NAME=${PYPI_INPUT:-$MODULE_NAME}
+
+echo "What is your github project name? (default: $PYPI_NAME)"
+read REPO_INPUT
+REPO_NAME=${REPO_INPUT:-$PYPI_NAME}
+
+echo "What is your readthedocs.org project name? (default: $PYPI_NAME)"
+read RTD_INPUT
+RTD_NAME=${RTD_INPUT:-$PYPI_NAME}
+
+echo "What is your project name (ex: at the top of the README)? (default: $REPO_NAME)"
+read PROJECT_INPUT
+PROJECT_NAME=${PROJECT_INPUT:-$REPO_NAME}
+
+echo "What is a one-liner describing the project?"
+read SHORT_DESCRIPTION
+
+_replace() {
+  local find_cmd=(find . ! -perm -u=x ! -path '*/.git/*' -type f)
+
+  if [[ $(uname) == Darwin ]]; then
+    "${find_cmd[@]}" -exec sed -i '' "$1" {} +
+  else
+    "${find_cmd[@]}" -exec sed -i "$1" {} +
+  fi
+}
+_replace "s/<MODULE_NAME>/$MODULE_NAME/g"
+_replace "s/<PYPI_NAME>/$PYPI_NAME/g"
+_replace "s/<REPO_NAME>/$REPO_NAME/g"
+_replace "s/<RTD_NAME>/$RTD_NAME/g"
+_replace "s/<PROJECT_NAME>/$PROJECT_NAME/g"
+_replace "s/<SHORT_DESCRIPTION>/$SHORT_DESCRIPTION/g"
+
+mkdir -p $MODULE_NAME
+touch $MODULE_NAME/__init__.py

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         "eth-rlp>=0.1.0,<1",
     ],
     setup_requires=['setuptools-markdown'],
+    python_requires='>=3.5, <4',
     extras_require=extras_require,
     py_modules=['eth_account'],
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         "eth-keys>=0.2.0b3,<0.3.0",
         "eth-utils>=1.0.2,<2",
         "hexbytes>=0.1.0,<1",
-        "eth-rlp>=0.1.1,<1",
+        "eth-rlp>=0.1.2,<1",
     ],
     setup_requires=['setuptools-markdown'],
     python_requires='>=3.5, <4',

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         "eth-keys>=0.2.0b3,<0.3.0",
         "eth-utils>=1.0.2,<2",
         "hexbytes>=0.1.0,<1",
-        "eth-rlp>=0.1.0,<1",
+        "eth-rlp>=0.1.1,<1",
     ],
     setup_requires=['setuptools-markdown'],
     python_requires='>=3.5, <4',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{35,36,py3}-core
+    py{35,36,py3}-core-rlp{0,1}
     lint
     doctest
 
@@ -29,6 +29,9 @@ basepython =
     py35: python3.5
     py36: python3.6
     pypy3: pypy3
+deps=
+    rlp0: rlp<1.0.0
+    rlp1: rlp>=1.0.0,<2.0.0
 extras=
     test
     doctest: doc


### PR DESCRIPTION
## What was wrong?

Fixes #18

## How was it fixed?

Upgrade to `eth-rlp` v0.1.1, which supports rlp v{0,1}.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://img.fireden.net/co/image/1457/64/1457643294207.jpg)
