### PR TITLE
Abstract BaseAccount for new signers to inherit 

### DIFF
--- a/docs/eth_account.rst
+++ b/docs/eth_account.rst
@@ -8,12 +8,7 @@ Account
     :members:
     :undoc-members:
 
-Local Account
-----------------------------
-
-.. automodule:: eth_account.local
-    :members:
-    :undoc-members:
+See :doc:`eth_account.signers` for alternative signers.
 
 AttributeDict
 -----------------------------------

--- a/docs/eth_account.signers.rst
+++ b/docs/eth_account.signers.rst
@@ -1,0 +1,29 @@
+Signers
+============================
+
+These classes abstract away the private key, as opposed to :class:`eth_account.account.Account`,
+which explicitly requires the private key on each usage.
+
+All the signer classes in this package must meet the
+interface specified by :class:`~eth_account.signers.base.BaseAccount`.
+
+Currently there is only one Local Signer.
+Some upcoming alternatives to the basic local signer include
+hierarchical deterministic (HD) wallets and hardware wallets.
+
+Local Signer
+---------------------------------
+
+.. automodule:: eth_account.signers.local
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Abstract Signer
+--------------------------------
+
+.. automodule:: eth_account.signers.base
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Contents
     :maxdepth: 3
 
     eth_account
+    eth_account.signers
     releases
 
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -39,7 +39,7 @@ Released Apr 6, 2018
 - Documentation
 
   - use ``getpass`` instead of typing in password manually
-  - :class:`eth_account.local.LocalAccount` attributes
+  - :class:`eth_account.signers.local.LocalAccount` attributes
   - readme improvements
   - more
 

--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -45,7 +45,7 @@ from eth_account.internal.transactions import (
     Transaction,
     vrs_from,
 )
-from eth_account.local import (
+from eth_account.signers.local import (
     LocalAccount,
 )
 

--- a/eth_account/local.py
+++ b/eth_account/local.py
@@ -1,0 +1,4 @@
+# For backwards compatibility of explicit LocalAccount imports:
+from eth_account.signers.local import (  # noqa: F401
+    LocalAccount,
+)

--- a/eth_account/signers/base.py
+++ b/eth_account/signers/base.py
@@ -1,0 +1,48 @@
+from abc import (
+    ABC,
+    abstractmethod,
+)
+
+
+class BaseAccount(ABC):
+    '''
+    A collection of convenience methods to sign transactions and message hashes.
+
+    :var str address: the checksummed public address for this account
+
+    .. code-block:: python
+
+        >>> my_account.address
+        "0xF0109fC8DF283027b6285cc889F5aA624EaC1F55"
+
+    Subclasses of :cls:`BaseAccount` should implement `__hash__` and `__eq__`,
+    where two accounts are the same if they can sign for the same address.
+    '''
+
+    @property
+    @abstractmethod
+    def address(self):
+        '''
+        The checksummed public address for this account.
+        '''
+        pass
+
+    @abstractmethod
+    def signHash(self, message_hash):
+        '''
+        Sign the hash of a message, as in :meth:`~eth_account.account.Account.signHash`
+        but without specifying the private key.
+
+        :var bytes message_hash: 32 byte hash of the message to sign
+        '''
+        pass
+
+    @abstractmethod
+    def signTransaction(self, transaction_dict):
+        '''
+        Sign a transaction, as in :meth:`~eth_account.account.Account.signTransaction`
+        but without specifying the private key.
+
+        :var dict transaction_dict: transaction with all fields specified
+        '''
+        pass

--- a/eth_account/signers/base.py
+++ b/eth_account/signers/base.py
@@ -8,9 +8,6 @@ class BaseAccount(ABC):
     '''
     Abstract class that defines a collection of convenience methods
     to sign transactions and message hashes.
-
-    Subclasses of :class:`BaseAccount` should implement `__hash__()` and `__eq__()`,
-    where two accounts are the same if they are the same class, and can sign for the same address.
     '''
 
     @property
@@ -46,3 +43,15 @@ class BaseAccount(ABC):
         :var dict transaction_dict: transaction with all fields specified
         '''
         pass
+
+    def __eq__(self, other):
+        '''
+        Equality test between two accounts.
+
+        Two accounts are considered the same if they are exactly the same type,
+        and can sign for the same address.
+        '''
+        return type(self) == type(other) and self.address == other.address
+
+    def __hash__(self):
+        return hash((type(self), self.address))

--- a/eth_account/signers/base.py
+++ b/eth_account/signers/base.py
@@ -6,17 +6,11 @@ from abc import (
 
 class BaseAccount(ABC):
     '''
-    A collection of convenience methods to sign transactions and message hashes.
+    Abstract class that defines a collection of convenience methods
+    to sign transactions and message hashes.
 
-    :var str address: the checksummed public address for this account
-
-    .. code-block:: python
-
-        >>> my_account.address
-        "0xF0109fC8DF283027b6285cc889F5aA624EaC1F55"
-
-    Subclasses of :cls:`BaseAccount` should implement `__hash__` and `__eq__`,
-    where two accounts are the same if they can sign for the same address.
+    Subclasses of :class:`BaseAccount` should implement `__hash__()` and `__eq__()`,
+    where two accounts are the same if they are the same class, and can sign for the same address.
     '''
 
     @property
@@ -24,6 +18,12 @@ class BaseAccount(ABC):
     def address(self):
         '''
         The checksummed public address for this account.
+
+        .. code-block:: python
+
+            >>> my_account.address
+            "0xF0109fC8DF283027b6285cc889F5aA624EaC1F55"
+
         '''
         pass
 

--- a/eth_account/signers/local.py
+++ b/eth_account/signers/local.py
@@ -66,9 +66,3 @@ class LocalAccount(BaseAccount):
 
     def __bytes__(self):
         return self.privateKey
-
-    def __hash__(self):
-        return hash(self.privateKey)
-
-    def __eq__(self, other):
-        return (isinstance(other, type(self))) and (self.privateKey == other.privateKey)

--- a/eth_account/signers/local.py
+++ b/eth_account/signers/local.py
@@ -1,8 +1,12 @@
-class LocalAccount(object):
+from eth_account.signers.base import (
+    BaseAccount,
+)
+
+
+class LocalAccount(BaseAccount):
     '''
     A collection of convenience methods to sign and encrypt, with an embedded private key.
 
-    :var str address: the checksummed public address for this account
     :var bytes privateKey: the 32-byte private key data
 
     .. code-block:: python
@@ -26,12 +30,16 @@ class LocalAccount(object):
         '''
         self._publicapi = account
 
-        self.address = key.public_key.to_checksum_address()
+        self._address = key.public_key.to_checksum_address()
 
         key_raw = key.to_bytes()
         self._privateKey = key_raw
 
         self._key_obj = key
+
+    @property
+    def address(self):
+        return self._address
 
     @property
     def privateKey(self):
@@ -42,26 +50,18 @@ class LocalAccount(object):
 
     def encrypt(self, password):
         '''
-        Sign a message, as in :meth:`~eth_account.account.Account.encrypt`
-        but without specifying the private key.
+        Generate a string with the encrypted key, as in
+        :meth:`~eth_account.account.Account.encrypt`, but without a private key argument.
         '''
         return self._publicapi.encrypt(self.privateKey, password)
 
     def signHash(self, message_hash):
-        '''
-        Sign the hash of a message, as in :meth:`~eth_account.account.Account.signHash`
-        but without specifying the private key.
-        '''
         return self._publicapi.signHash(
             message_hash,
             private_key=self.privateKey,
         )
 
     def signTransaction(self, transaction_dict):
-        '''
-        Sign a transaction, as in :meth:`~eth_account.account.Account.signTransaction`
-        but without specifying the private key.
-        '''
         return self._publicapi.signTransaction(transaction_dict, self.privateKey)
 
     def __bytes__(self):


### PR DESCRIPTION
## What was wrong?

Fixes #28 

## How was it fixed?

New abstract class and docs. Moved `LocalAccount` to `signers` module.

Seeking feedback: maybe rename `*Account` to `*Signer`?

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://78.media.tumblr.com/78e968cefc8e1407abedcea933f7c16c/tumblr_p5y0eeavIR1w8f1tco1_500.jpg)