### PR TITLE
Allow KDF to be provided for private key encryption

### DIFF
--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -51,7 +51,6 @@ from eth_account.signers.local import (
 
 
 class Account(object):
-
     '''
     This is the primary entry point for working with Ethereum private keys.
 
@@ -134,7 +133,6 @@ class Account(object):
         password_bytes = text_if_str(to_bytes, password)
         return HexBytes(decode_keyfile_json(keyfile, password_bytes))
 
-    # TODO - Update documentation to reflect new KDF param
     @staticmethod
     def encrypt(private_key, password, kdf=None):
         '''

--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -3,10 +3,6 @@ from collections import (
 )
 import json
 import os
-import sys
-from types import (
-    ModuleType,
-)
 
 from cytoolz import (
     dissoc,
@@ -54,25 +50,12 @@ from eth_account.signers.local import (
 )
 
 
-class _AccountModule(ModuleType):
+class Account(object):
 
     '''
     TODO - Documentation
     '''
-    _defaultKDF = os.getenv('ETH_ACCOUNT_KDF', 'scrypt')
-
-    @property
-    def defaultKDF(self):
-        '''
-        TODO - Documentation
-        '''
-        return type(self)._defaultKDF
-
-
-sys.modules[__name__].__class__ = _AccountModule
-
-
-class Account(object):
+    default_kdf = os.getenv('ETH_ACCOUNT_KDF', 'scrypt')
 
     '''
     This is the primary entry point for working with Ethereum private keys.
@@ -151,7 +134,7 @@ class Account(object):
 
     # TODO - Update documentation to reflect new KDF param
     @staticmethod
-    def encrypt(private_key, password, kdf=getattr(sys.modules[__module__], 'defaultKDF')):  # noqa: E501,F821
+    def encrypt(private_key, password, kdf=None):
         '''
         Creates a dictionary with an encrypted version of your private key.
         To import this keyfile into Ethereum clients like geth and parity:
@@ -192,6 +175,9 @@ class Account(object):
             key_bytes = private_key.to_bytes()
         else:
             key_bytes = HexBytes(private_key)
+
+        if kdf is None:
+            kdf = __class__.default_kdf  # noqa: F821
 
         password_bytes = text_if_str(to_bytes, password)
         assert len(key_bytes) == 32

--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -53,16 +53,18 @@ from eth_account.signers.local import (
 class Account(object):
 
     '''
-    TODO - Documentation
-    '''
-    default_kdf = os.getenv('ETH_ACCOUNT_KDF', 'scrypt')
-
-    '''
     This is the primary entry point for working with Ethereum private keys.
 
     It does **not** require a connection to an Ethereum node.
     '''
     _keys = keys
+
+    default_kdf = os.getenv('ETH_ACCOUNT_KDF', 'scrypt')
+    '''
+    The default key deriviation function (KDF) to use when encrypting a private key. If the
+    environment variable :envvar:`ETH_ACCOUNT_KDF` is set, it's value will be used as the default.
+    Otherwise, 'scrypt' will be used as the default.
+    '''
 
     @combomethod
     def create(self, extra_entropy=''):
@@ -144,6 +146,7 @@ class Account(object):
         :param private_key: The raw private key
         :type private_key: hex str, bytes, int or :class:`eth_keys.datatypes.PrivateKey`
         :param str password: The password which you will need to unlock the account in your client
+        :param str kdf: The key derivation function to use when encrypting your private key
         :returns: The data to use in your encrypted file
         :rtype: dict
 
@@ -155,18 +158,27 @@ class Account(object):
                 getpass.getpass()
             )
 
-            {'address': '5ce9454909639d2d17a3f753ce7d93fa0b9ab12e',
-             'crypto': {'cipher': 'aes-128-ctr',
-              'cipherparams': {'iv': '78f214584844e0b241b433d7c3bb8d5f'},
-              'ciphertext': 'd6dbb56e4f54ba6db2e8dc14df17cb7352fdce03681dd3f90ce4b6c1d5af2c4f',
-              'kdf': 'pbkdf2',
-              'kdfparams': {'c': 1000000,
-               'dklen': 32,
-               'prf': 'hmac-sha256',
-               'salt': '45cf943b4de2c05c2c440ef96af914a2'},
-              'mac': 'f5e1af09df5ded25c96fcf075ada313fb6f79735a914adc8cb02e8ddee7813c3'},
-             'id': 'b812f3f9-78cc-462a-9e89-74418aa27cb0',
-             'version': 3}
+            {
+                'address': '5ce9454909639d2d17a3f753ce7d93fa0b9ab12e',
+                'crypto': {
+                    'cipher': 'aes-128-ctr',
+                    'cipherparams': {
+                        'iv': '0b7845a5c3597d3d378bde9b7c7319b7'
+                    },
+                    'ciphertext': 'a494f1feb3c854e99c1ff01e6aaa17d43c0752009073503b908457dc8de5d2a5',  # noqa: E501
+                    'kdf': 'scrypt',
+                    'kdfparams': {
+                        'dklen': 32,
+                        'n': 262144,
+                        'p': 8,
+                        'r': 1,
+                        'salt': '13c4a48123affaa29189e9097726c698'
+                    },
+                    'mac': 'f4cfb027eb0af9bd7a320b4374a3fa7bef02cfbafe0ec5d1fd7ad129401de0b1'
+                },
+                'id': 'a60e0578-0e5b-4a75-b991-d55ec6451a6f',
+                'version': 3
+            }
 
              >>> with open('my-keyfile', 'w') as f:
                  f.write(json.dumps(encrypted))

--- a/eth_account/signers/local.py
+++ b/eth_account/signers/local.py
@@ -26,7 +26,7 @@ class LocalAccount(BaseAccount):
     def __init__(self, key, account):
         '''
         :param eth_keys.PrivateKey key: to prefill in private key execution
-        :param web3.account.Account account: the key-unaware management API
+        :param ~eth_account.account.Account account: the key-unaware management API
         '''
         self._publicapi = account
 
@@ -48,12 +48,15 @@ class LocalAccount(BaseAccount):
         '''
         return self._privateKey
 
-    def encrypt(self, password):
+    def encrypt(self, password, kdf=None):
         '''
         Generate a string with the encrypted key, as in
         :meth:`~eth_account.account.Account.encrypt`, but without a private key argument.
         '''
-        return self._publicapi.encrypt(self.privateKey, password)
+        if kdf is None:
+            return self._publicapi.encrypt(self.privateKey, password)
+        else:
+            return self._publicapi.encrypt(self.privateKey, password, kdf)
 
     def signHash(self, message_hash):
         return self._publicapi.signHash(


### PR DESCRIPTION
## What was wrong?

Fixes #3 
Fixes #4 

## How was it fixed?

- Updated the `Account#encrypt` and `LocalAccount#encrypt` methods to take an optional 'kdf' parameter to be used when generating the encrypted keyfile (Issue #3)
- Switched to using 'scrypt' as the default KDF for keyfile encryption instead of the 'pbkdf2' default from eth-keyfile (Issue #4). If the environment variable `ETH_ACCOUNT_KDF` is set, that will be used for the default KDF if none is provided when calling `Account#encrypt` or `LocalAccount#encrypt`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://img-aws.ehowcdn.com/750x428p/s3-us-west-1.amazonaws.com/contentlab.studiod/getty/00b7ac219f6b444c84c520912db4a34b)
