### PR TITLE
Use updated python on readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,2 @@
+build:
+    image: latest


### PR DESCRIPTION
## What was wrong?

fixes #39 

## How was it fixed?

Use a later build server on RTD to get a later version of python.

It looks like python defaults to py3.6 on the latest build infrastructure

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static1.squarespace.com/static/52f97658e4b0c3faf4f21b55/t/52f99acfe4b0bddfe2cc37a2/1392089809290/shutterstock_113282740.jpg?format=750w)
