### PR TITLE
Switch Account#encrypt to @classmethod

### DIFF
--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -133,8 +133,8 @@ class Account(object):
         password_bytes = text_if_str(to_bytes, password)
         return HexBytes(decode_keyfile_json(keyfile, password_bytes))
 
-    @staticmethod
-    def encrypt(private_key, password, kdf=None):
+    @classmethod
+    def encrypt(cls, private_key, password, kdf=None):
         '''
         Creates a dictionary with an encrypted version of your private key.
         To import this keyfile into Ethereum clients like geth and parity:
@@ -187,7 +187,7 @@ class Account(object):
             key_bytes = HexBytes(private_key)
 
         if kdf is None:
-            kdf = __class__.default_kdf  # noqa: F821
+            kdf = cls.default_kdf
 
         password_bytes = text_if_str(to_bytes, password)
         assert len(key_bytes) == 32


### PR DESCRIPTION
## What was wrong?

Switch to a `@classmethod` for `Account#encrypt` instead of calling `__class__` from inside a `@staticmethod`.

Reference: https://github.com/ethereum/eth-account/pull/38#discussion_r225709792

## How was it fixed?

Switch to `@staticmethod`, call `cls.default_kdf`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/SB-qEYVdvXA/hqdefault.jpg)