### PR TITLE
Run doctests with tox

### DIFF
--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -106,21 +106,21 @@ class Account(object):
         .. code-block:: python
 
             >>> encrypted = {
-             'address': '5ce9454909639d2d17a3f753ce7d93fa0b9ab12e',
-             'crypto': {'cipher': 'aes-128-ctr',
-              'cipherparams': {'iv': '78f214584844e0b241b433d7c3bb8d5f'},
-              'ciphertext': 'd6dbb56e4f54ba6db2e8dc14df17cb7352fdce03681dd3f90ce4b6c1d5af2c4f',
-              'kdf': 'pbkdf2',
-              'kdfparams': {'c': 1000000,
-               'dklen': 32,
-               'prf': 'hmac-sha256',
-               'salt': '45cf943b4de2c05c2c440ef96af914a2'},
-              'mac': 'f5e1af09df5ded25c96fcf075ada313fb6f79735a914adc8cb02e8ddee7813c3'},
-             'id': 'b812f3f9-78cc-462a-9e89-74418aa27cb0',
-             'version': 3}
+            ... 'address': '5ce9454909639d2d17a3f753ce7d93fa0b9ab12e',
+            ... 'crypto': {'cipher': 'aes-128-ctr',
+            ...  'cipherparams': {'iv': '78f214584844e0b241b433d7c3bb8d5f'},
+            ...  'ciphertext': 'd6dbb56e4f54ba6db2e8dc14df17cb7352fdce03681dd3f90ce4b6c1d5af2c4f',
+            ...  'kdf': 'pbkdf2',
+            ...  'kdfparams': {'c': 1000000,
+            ...   'dklen': 32,
+            ...   'prf': 'hmac-sha256',
+            ...   'salt': '45cf943b4de2c05c2c440ef96af914a2'},
+            ...  'mac': 'f5e1af09df5ded25c96fcf075ada313fb6f79735a914adc8cb02e8ddee7813c3'},
+            ... 'id': 'b812f3f9-78cc-462a-9e89-74418aa27cb0',
+            ... 'version': 3}
 
             >>> import getpass
-            >>> Account.decrypt(encrypted, getpass.getpass())
+            >>> Account.decrypt(encrypted, getpass.getpass()) # doctest: +SKIP
             HexBytes('0xb25c7db31feed9122727bf0939dc769a96564b2de4c4726d035b36ecf1e5b364')
 
         """
@@ -156,11 +156,10 @@ class Account(object):
         .. code-block:: python
 
             >>> import getpass
-            >>> encrypted = Account.encrypt(
-                0xb25c7db31feed9122727bf0939dc769a96564b2de4c4726d035b36ecf1e5b364,
-                getpass.getpass()
-            )
-
+            >>> encrypted = Account.encrypt( # doctest: +SKIP
+            ...     0xb25c7db31feed9122727bf0939dc769a96564b2de4c4726d035b36ecf1e5b364,
+            ...     getpass.getpass()
+            ... )
             {
                 'address': '5ce9454909639d2d17a3f753ce7d93fa0b9ab12e',
                 'crypto': {
@@ -183,8 +182,8 @@ class Account(object):
                 'version': 3
             }
 
-             >>> with open('my-keyfile', 'w') as f:
-                 f.write(json.dumps(encrypted))
+            >>> with open('my-keyfile', 'w') as f: # doctest: +SKIP
+            ...    f.write(json.dumps(encrypted))
         """
         if isinstance(private_key, keys.PrivateKey):
             key_bytes = private_key.to_bytes()

--- a/eth_account/messages.py
+++ b/eth_account/messages.py
@@ -187,13 +187,13 @@ def encode_defunct(
         SignableMessage(version=b'E', header=b'thereum Signed Message:\n6', body=b'I\xe2\x99\xa5SF')
 
         # these four also produce the same hash:
-        >>> encode_defunct(w3.toBytes(text=message_text))
+        >>> encode_defunct(w3.toBytes(text=message_text)) # doctest: +SKIP
         SignableMessage(version=b'E', header=b'thereum Signed Message:\n6', body=b'I\xe2\x99\xa5SF')
 
         >>> encode_defunct(bytes(message_text, encoding='utf-8'))
         SignableMessage(version=b'E', header=b'thereum Signed Message:\n6', body=b'I\xe2\x99\xa5SF')
 
-        >>> Web3.toHex(text=message_text)
+        >>> Web3.toHex(text=message_text) # doctest: +SKIP
         '0x49e299a55346'
         >>> encode_defunct(hexstr='0x49e299a55346')
         SignableMessage(version=b'E', header=b'thereum Signed Message:\n6', body=b'I\xe2\x99\xa5SF')

--- a/eth_account/signers/base.py
+++ b/eth_account/signers/base.py
@@ -22,7 +22,7 @@ class BaseAccount(ABC):
 
         .. code-block:: python
 
-            >>> my_account.address
+            >>> my_account.address # doctest: +SKIP
             "0xF0109fC8DF283027b6285cc889F5aA624EaC1F55"
 
         """

--- a/eth_account/signers/local.py
+++ b/eth_account/signers/local.py
@@ -13,16 +13,16 @@ class LocalAccount(BaseAccount):
 
     .. code-block:: python
 
-        >>> my_local_account.address
+        >>> my_local_account.address # doctest: +SKIP
         "0xF0109fC8DF283027b6285cc889F5aA624EaC1F55"
-        >>> my_local_account.key
+        >>> my_local_account.key # doctest: +SKIP
         b"\x01\x23..."
 
     You can also get the private key by casting the account to :class:`bytes`:
 
     .. code-block:: python
 
-        >>> bytes(my_local_account)
+        >>> bytes(my_local_account) # doctest: +SKIP
         b"\\x01\\x23..."
     """
     def __init__(self, key, account):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts= -v --showlocals --durations 10
+addopts= -v --showlocals --doctest-modules --durations 10
 python_paths= .
 xfail_strict=true
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ ignore=
 [testenv]
 usedevelop=True
 commands=
-    core: pytest {posargs:tests/core}
+    core: pytest {posargs:tests/core eth_account}
     doctest: make -C {toxinidir}/docs doctest
 basepython =
     doctest: python


### PR DESCRIPTION
## What was wrong?

Currently the CI doesn't run doctests.
However keep in mind that now we have 5 tests failing.
If you're interested with the approach, I can also fix them in this PR or in another one.

Issue #9 

## How was it fixed?
Enabling doctests via `tox.ini` and `pytest.ini`

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/24973/47856647-fd339480-dde7-11e8-8b2f-1cd6e847934f.png)
