### PR TITLE
Allow iterations (work factor) to be provided to Account#encrypt

### DIFF
--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -145,7 +145,7 @@ class Account(object):
         :type private_key: hex str, bytes, int or :class:`eth_keys.datatypes.PrivateKey`
         :param str password: The password which you will need to unlock the account in your client
         :param str kdf: The key derivation function to use when encrypting your private key
-        :param str iterations: The work factor for the key derivation function
+        :param int iterations: The work factor for the key derivation function
         :returns: The data to use in your encrypted file
         :rtype: dict
 

--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -193,10 +193,7 @@ class Account(object):
         password_bytes = text_if_str(to_bytes, password)
         assert len(key_bytes) == 32
 
-        if iterations is None:
-            return create_keyfile_json(key_bytes, password_bytes, kdf=kdf)
-        else:
-            return create_keyfile_json(key_bytes, password_bytes, kdf=kdf, iterations=iterations)
+        return create_keyfile_json(key_bytes, password_bytes, kdf=kdf, iterations=iterations)
 
     @combomethod
     def privateKeyToAccount(self, private_key):

--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -134,7 +134,7 @@ class Account(object):
         return HexBytes(decode_keyfile_json(keyfile, password_bytes))
 
     @classmethod
-    def encrypt(cls, private_key, password, kdf=None):
+    def encrypt(cls, private_key, password, kdf=None, iterations=None):
         '''
         Creates a dictionary with an encrypted version of your private key.
         To import this keyfile into Ethereum clients like geth and parity:
@@ -145,6 +145,7 @@ class Account(object):
         :type private_key: hex str, bytes, int or :class:`eth_keys.datatypes.PrivateKey`
         :param str password: The password which you will need to unlock the account in your client
         :param str kdf: The key derivation function to use when encrypting your private key
+        :param str iterations: The work factor for the key derivation function
         :returns: The data to use in your encrypted file
         :rtype: dict
 
@@ -191,7 +192,11 @@ class Account(object):
 
         password_bytes = text_if_str(to_bytes, password)
         assert len(key_bytes) == 32
-        return create_keyfile_json(key_bytes, password_bytes, kdf=kdf)
+
+        if iterations is None:
+            return create_keyfile_json(key_bytes, password_bytes, kdf=kdf)
+        else:
+            return create_keyfile_json(key_bytes, password_bytes, kdf=kdf, iterations=iterations)
 
     @combomethod
     def privateKeyToAccount(self, private_key):

--- a/eth_account/signers/local.py
+++ b/eth_account/signers/local.py
@@ -48,7 +48,7 @@ class LocalAccount(BaseAccount):
         '''
         return self._privateKey
 
-    def encrypt(self, password, kdf=None):
+    def encrypt(self, password, kdf=None, iterations=None):
         '''
         Generate a string with the encrypted key, as in
         :meth:`~eth_account.account.Account.encrypt`, but without a private key argument.
@@ -56,7 +56,12 @@ class LocalAccount(BaseAccount):
         if kdf is None:
             return self._publicapi.encrypt(self.privateKey, password)
         else:
-            return self._publicapi.encrypt(self.privateKey, password, kdf)
+            return self._publicapi.encrypt(
+                self.privateKey,
+                password,
+                kdf=kdf,
+                iterations=iterations
+            )
 
     def signHash(self, message_hash):
         return self._publicapi.signHash(

--- a/eth_account/signers/local.py
+++ b/eth_account/signers/local.py
@@ -53,15 +53,7 @@ class LocalAccount(BaseAccount):
         Generate a string with the encrypted key, as in
         :meth:`~eth_account.account.Account.encrypt`, but without a private key argument.
         '''
-        if kdf is None:
-            return self._publicapi.encrypt(self.privateKey, password)
-        else:
-            return self._publicapi.encrypt(
-                self.privateKey,
-                password,
-                kdf=kdf,
-                iterations=iterations
-            )
+        return self._publicapi.encrypt(self.privateKey, password, kdf=kdf, iterations=iterations)
 
     def signHash(self, message_hash):
         return self._publicapi.signHash(

--- a/tests/core/test_accounts.py
+++ b/tests/core/test_accounts.py
@@ -524,6 +524,8 @@ def test_eth_account_encrypt(
         assert encrypted['crypto']['kdfparams']['c'] == expected_iterations
     elif expected_kdf == 'scrypt':
         assert encrypted['crypto']['kdfparams']['n'] == expected_iterations
+    else:
+        raise Exception("test must be upgraded to confirm iterations with kdf %s" % expected_kdf)
 
     decrypted_key = acct.decrypt(encrypted, password)
 
@@ -570,6 +572,8 @@ def test_eth_account_prepared_encrypt(
         assert encrypted['crypto']['kdfparams']['c'] == expected_iterations
     elif expected_kdf == 'scrypt':
         assert encrypted['crypto']['kdfparams']['n'] == expected_iterations
+    else:
+        raise Exception("test must be upgraded to confirm iterations with kdf %s" % expected_kdf)
 
     decrypted_key = acct.decrypt(encrypted, password)
 

--- a/tests/core/test_accounts.py
+++ b/tests/core/test_accounts.py
@@ -6,6 +6,9 @@ import pytest
 from cytoolz import (
     dissoc,
 )
+from eth_keyfile.keyfile import (
+    get_default_work_factor_for_kdf,
+)
 from eth_keys import (
     keys,
 )
@@ -421,53 +424,63 @@ def test_eth_account_recover_transaction_from_eth_test(acct, transaction):
 
 def get_encrypt_test_params():
     """
-    Params for testing Account#encrypt. Due to not being able to provie fixtures to
+    Params for testing Account#encrypt. Due to not being able to provide fixtures to
     pytest.mark.parameterize, we opt for creating the params in a non-fixture method
-    here instead of providing fixtures for the public key, password, and private key.
+    here instead of providing fixtures for the private key and password.
     """
-    public_key = '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318'
+    key = '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318'
+    key_bytes = to_bytes(hexstr=key)
+    private_key = keys.PrivateKey(HexBytes(key))
     password = 'test!'
 
     # 'private_key, password, kdf, iterations, expected_decrypted_key, expected_kdf'
     return [
         (
-            public_key,
+            key,
             password,
             None,
             None,
-            to_bytes(hexstr=public_key),
+            key_bytes,
             'scrypt'
         ),
         (
-            public_key,
+            private_key,
+            password,
+            None,
+            None,
+            private_key.to_bytes(),
+            'scrypt'
+        ),
+        (
+            key,
             password,
             'pbkdf2',
             None,
-            to_bytes(hexstr=public_key),
+            key_bytes,
             'pbkdf2'
         ),
         (
-            keys.PrivateKey(HexBytes(public_key)),
+            key,
             password,
             None,
-            None,
-            keys.PrivateKey(HexBytes(public_key)).to_bytes(),
+            1024,
+            key_bytes,
             'scrypt'
         ),
         (
-            public_key,
+            key,
             password,
             'pbkdf2',
             1024,
-            to_bytes(hexstr=public_key),
+            key_bytes,
             'pbkdf2'
         ),
         (
-            public_key,
+            key,
             password,
             'scrypt',
             1024,
-            to_bytes(hexstr=public_key),
+            key_bytes,
             'scrypt'
         ),
     ]
@@ -478,8 +491,9 @@ def get_encrypt_test_params():
     get_encrypt_test_params(),
     ids=[
         'hex_str',
-        'hex_str_provided_kdf',
         'eth_keys.datatypes.PrivateKey',
+        'hex_str_provided_kdf',
+        'hex_str_default_kdf_provided_iterations',
         'hex_str_pbkdf2_provided_iterations',
         'hex_str_scrypt_provided_iterations',
     ]
@@ -501,6 +515,16 @@ def test_eth_account_encrypt(
     assert encrypted['version'] == 3
     assert encrypted['crypto']['kdf'] == expected_kdf
 
+    if iterations is None:
+        expected_iterations = get_default_work_factor_for_kdf(expected_kdf)
+    else:
+        expected_iterations = iterations
+
+    if expected_kdf == 'pbkdf2':
+        assert encrypted['crypto']['kdfparams']['c'] == expected_iterations
+    elif expected_kdf == 'scrypt':
+        assert encrypted['crypto']['kdfparams']['n'] == expected_iterations
+
     decrypted_key = acct.decrypt(encrypted, password)
 
     assert decrypted_key == expected_decrypted_key
@@ -511,8 +535,9 @@ def test_eth_account_encrypt(
     get_encrypt_test_params(),
     ids=[
         'hex_str',
-        'hex_str_provided_kdf',
         'eth_keys.datatypes.PrivateKey',
+        'hex_str_provided_kdf',
+        'hex_str_default_kdf_provided_iterations',
         'hex_str_pbkdf2_provided_iterations',
         'hex_str_scrypt_provided_iterations',
     ]
@@ -535,6 +560,16 @@ def test_eth_account_prepared_encrypt(
     assert encrypted['address'] == '2c7536e3605d9c16a7a3d7b1898e529396a65c23'
     assert encrypted['version'] == 3
     assert encrypted['crypto']['kdf'] == expected_kdf
+
+    if iterations is None:
+        expected_iterations = get_default_work_factor_for_kdf(expected_kdf)
+    else:
+        expected_iterations = iterations
+
+    if expected_kdf == 'pbkdf2':
+        assert encrypted['crypto']['kdfparams']['c'] == expected_iterations
+    elif expected_kdf == 'scrypt':
+        assert encrypted['crypto']['kdfparams']['n'] == expected_iterations
 
     decrypted_key = acct.decrypt(encrypted, password)
 

--- a/tests/core/test_accounts.py
+++ b/tests/core/test_accounts.py
@@ -419,7 +419,7 @@ def test_eth_account_recover_transaction_from_eth_test(acct, transaction):
     assert acct.recoverTransaction(raw_txn) == expected_sender
 
 
-def encrypt_mark_params():
+def get_encrypt_test_params():
     """
     Params for testing Account#encrypt. Due to not being able to provie fixtures to
     pytest.mark.parameterize, we opt for creating the params in a non-fixture method
@@ -458,7 +458,7 @@ def encrypt_mark_params():
             public_key,
             password,
             'pbkdf2',
-            2000000,
+            1024,
             to_bytes(hexstr=public_key),
             'pbkdf2'
         ),
@@ -466,7 +466,7 @@ def encrypt_mark_params():
             public_key,
             password,
             'scrypt',
-            524288,
+            1024,
             to_bytes(hexstr=public_key),
             'scrypt'
         ),
@@ -475,7 +475,7 @@ def encrypt_mark_params():
 
 @pytest.mark.parametrize(
     'private_key, password, kdf, iterations, expected_decrypted_key, expected_kdf',
-    encrypt_mark_params(),
+    get_encrypt_test_params(),
     ids=[
         'hex_str',
         'hex_str_provided_kdf',
@@ -508,7 +508,7 @@ def test_eth_account_encrypt(
 
 @pytest.mark.parametrize(
     'private_key, password, kdf, iterations, expected_decrypted_key, expected_kdf',
-    encrypt_mark_params(),
+    get_encrypt_test_params(),
     ids=[
         'hex_str',
         'hex_str_provided_kdf',


### PR DESCRIPTION
## What was wrong?

* Resolves #48
* **(EDIT: Moved to #53)**`pytest-xdist 1.25.0 has requirement pytest>=3.6.0, but you'll have pytest 3.3.2 which is incompatible.` ([1.24.1](https://github.com/pytest-dev/pytest-xdist/blob/v1.24.1/setup.py#L3) vs. [1.25.0](https://github.com/pytest-dev/pytest-xdist/blob/v1.25.0/setup.py#L3))

## How was it fixed?

* Expose `iterations` as an optional param to `Account#encrypt`
* **(EDIT: Moved to #53)** Uplift `pytest` to `>=3.6.0` and fix the resulting breaking changes in tests accordingly
* Tests added for providing the work factor to Account.encrypt

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.vice.com/vice/images/articles/meta/2015/05/28/why-do-i-want-to-crush-cute-animals-1432782372.jpg)
