### PR TITLE
Upgrade pytest to >= 3.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import (
 
 extras_require={
     'test': [
-        "pytest==3.3.2",
+        "pytest>=3.6.0",
         "tox>=2.9.1,<3",
     ],
     'lint': [


### PR DESCRIPTION
## What was wrong?

Prerequisite for Issue #48 

There is no restriction on pytest-dist version, which introduces the
following error:

pytest-xdist 1.25.0 has requirement pytest>=3.6.0, but you'll have pytest 3.3.2 which is incompatible.

When upgrading to pytest >= 3.6.0, fixtures can no longer be called
directly as functions and thus the broken tests resulting from the
version bump of pytest had to be fixed.

## How was it fixed?

Bump pytest to `>= 3.6.0` and fix tests accordingly.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/96/a4/fb/96a4fb8a0eb8529da389c5cbe1bdba0a.jpg)