### PR TITLE
Implement signing data with intended validator as part of EIP 191

### DIFF
--- a/eth_account/__init__.py
+++ b/eth_account/__init__.py
@@ -1,1 +1,3 @@
-from eth_account.account import Account  # noqa: F401
+from eth_account.account import (  # noqa: F401
+    Account,
+)

--- a/eth_account/_utils/signing.py
+++ b/eth_account/_utils/signing.py
@@ -18,6 +18,10 @@ from eth_account._utils.transactions import (
 CHAIN_ID_OFFSET = 35
 V_OFFSET = 27
 
+# signature versions
+PERSONAL_SIGN_VERSION = b'E'  # Hex value 0x45
+INTENDED_VALIDATOR_SIGN_VERSION = b'\x00'  # Hex value 0x00
+
 
 def sign_transaction_dict(eth_key, transaction_dict):
     # generate RLP-serializable transaction, with defaults filled
@@ -50,11 +54,11 @@ def signature_wrapper(message, signature_version, version_specific_data):
             type(signature_version))
         )
 
-    if signature_version == b'E':
+    if signature_version == PERSONAL_SIGN_VERSION:
         preamble = b'\x19Ethereum Signed Message:\n'
         size = str(len(message)).encode('utf-8')
         return preamble + size + message
-    elif signature_version == b'\x00':
+    elif signature_version == INTENDED_VALIDATOR_SIGN_VERSION:
         wallet_address = to_bytes(hexstr=version_specific_data)
         if len(wallet_address) != 20:
             raise TypeError("Invalid Wallet Address: {}".format(version_specific_data))
@@ -63,7 +67,10 @@ def signature_wrapper(message, signature_version, version_specific_data):
     else:
         raise NotImplementedError(
             "Currently supported signature versions are: {0}, {1}. ".
-            format('0x' + b'\x00'.hex(), '0x' + b'E'.hex()) +
+            format(
+                '0x' + INTENDED_VALIDATOR_SIGN_VERSION.hex(),
+                '0x' + PERSONAL_SIGN_VERSION.hex()
+            ) +
             "But received signature version {}".format('0x' + signature_version.hex())
         )
 

--- a/eth_account/_utils/signing.py
+++ b/eth_account/_utils/signing.py
@@ -44,7 +44,11 @@ def sign_transaction_dict(eth_key, transaction_dict):
 @curry
 def signature_wrapper(message, signature_version, version_specific_data):
     if not isinstance(message, bytes):
-        raise TypeError("Message is not of the type {}, expected bytes".format(type(message)))
+        raise TypeError("Message is of the type {}, expected bytes".format(type(message)))
+    if not isinstance(signature_version, bytes):
+        raise TypeError("Signature Version is of the type {}, expected bytes".format(
+            type(signature_version))
+        )
 
     if signature_version == b'E':
         preamble = b'\x19Ethereum Signed Message:\n'
@@ -58,7 +62,9 @@ def signature_wrapper(message, signature_version, version_specific_data):
         return wrapped_message
     else:
         raise NotImplementedError(
-            "Only EIP 191 type signature wrapping is currently supported"
+            "Currently supported signature versions are: {0}, {1}. ".
+            format('0x' + b'\x00'.hex(), '0x' + b'E'.hex()) +
+            "But received signature version {}".format('0x' + signature_version.hex())
         )
 
 

--- a/eth_account/_utils/signing.py
+++ b/eth_account/_utils/signing.py
@@ -58,7 +58,7 @@ def signature_wrapper(message, signature_version, version_specific_data):
         return wrapped_message
     else:
         raise NotImplementedError(
-            "Only Personal Sign and Signing of data with intended validator is supported"
+            "Only EIP 191 type signature wrapping is currently supported"
         )
 
 

--- a/eth_account/messages.py
+++ b/eth_account/messages.py
@@ -15,8 +15,8 @@ from eth_account._utils.signing import (
 
 
 def defunct_hash_message(
-        *,
         primitive=None,
+        *,
         hexstr=None,
         text=None,
         signature_version=b'E',
@@ -24,21 +24,20 @@ def defunct_hash_message(
     '''
     Convert the provided message into a message hash, to be signed.
     This provides the same prefix and hashing approach as
-    :meth:`w3.eth.sign() <web3.eth.Eth.sign>`. The message will by default
-    be prepended with text defined in EIP-191 as
-    version 'E': ``b'\\x19Ethereum Signed Message:\\n'``
+    :meth:`w3.eth.sign() <web3.eth.Eth.sign>`.
+    Currently you can only specify the ``signature_version`` as following.
+    version ``0x45`` (version ``E``): ``b'\\x19Ethereum Signed Message:\\n'``
     concatenated with the number of bytes in the message.
-    You can also specify the ``signature_version`` as
-        1) version ``0``: Sign data with intended validator (EIP 191)
-           Here the version_specific_data would be a hexstr which is the 20 bytes account address
-        2) version ``1``: Sign the structured data (EIP 712)
-           Here the version_specific_data would be <WIP(Needs to be updated)>
+    NOTE: This is the defualt version followed, if the signature_version is not specified.
+    version ``0x00`` (version ``0``): Sign data with intended validator (EIP 191).
+    Here the version_specific_data would be a hexstr which is the 20 bytes account address
+    of the intended validator.
 
-    Awkwardly, the number of bytes in the message is encoded in decimal ascii. So
-    if the message is 'abcde', then the length is encoded as the ascii
+    For version ``0x45`` (version ``E``), Awkwardly, the number of bytes in the message is
+    encoded in decimal ascii. So if the message is 'abcde', then the length is encoded as the ascii
     character '5'. This is one of the reasons that this message format is not preferred.
     There is ambiguity when the message '00' is encoded, for example.
-    Only use this method if you must have compatibility with
+    Only use this method with version ``E`` if you must have compatibility with
     :meth:`w3.eth.sign() <web3.eth.Eth.sign>`.
 
     Supply exactly one of the three arguments:
@@ -49,7 +48,7 @@ def defunct_hash_message(
     :param str hexstr: the message encoded as hex
     :param str text: the message as a series of unicode characters (a normal Py3 str)
     :param bytes signature_version: a byte indicating which kind of prefix is to be added (EIP 191)
-    :param version_specific_data: the data which is needed for adding the prefix (EIP 191)
+    :param version_specific_data: the data which is related to the prefix (EIP 191)
     :returns: The hash of the message, after adding the prefix
     :rtype: ~hexbytes.main.HexBytes
 

--- a/eth_account/messages.py
+++ b/eth_account/messages.py
@@ -26,12 +26,15 @@ def defunct_hash_message(
     This provides the same prefix and hashing approach as
     :meth:`w3.eth.sign() <web3.eth.Eth.sign>`.
     Currently you can only specify the ``signature_version`` as following.
-    version ``0x45`` (version ``E``): ``b'\\x19Ethereum Signed Message:\\n'``
-    concatenated with the number of bytes in the message.
-    .. note:: This is the defualt version followed, if the signature_version is not specified.
-    version ``0x00`` (version ``0``): Sign data with intended validator (EIP 191).
-    Here the version_specific_data would be a hexstr which is the 20 bytes account address
-    of the intended validator.
+
+    * **Version** ``0x45`` (version ``E``):  ``b'\\x19Ethereum Signed Message:\\n'``
+      concatenated with the number of bytes in the message.
+
+        .. note:: This is the defualt version followed, if the signature_version is not specified.
+
+    * **Version** ``0x00`` (version ``0``): Sign data with intended validator (EIP 191).
+      Here the version_specific_data would be a hexstr which is the 20 bytes account address
+      of the intended validator.
 
     For version ``0x45`` (version ``E``), Awkwardly, the number of bytes in the message is
     encoded in decimal ascii. So if the message is 'abcde', then the length is encoded as the ascii

--- a/eth_account/messages.py
+++ b/eth_account/messages.py
@@ -28,7 +28,7 @@ def defunct_hash_message(
     Currently you can only specify the ``signature_version`` as following.
     version ``0x45`` (version ``E``): ``b'\\x19Ethereum Signed Message:\\n'``
     concatenated with the number of bytes in the message.
-    NOTE: This is the defualt version followed, if the signature_version is not specified.
+    .. note:: This is the defualt version followed, if the signature_version is not specified.
     version ``0x00`` (version ``0``): Sign data with intended validator (EIP 191).
     Here the version_specific_data would be a hexstr which is the 20 bytes account address
     of the intended validator.

--- a/eth_account/messages.py
+++ b/eth_account/messages.py
@@ -14,14 +14,25 @@ from eth_account._utils.signing import (
 )
 
 
-def defunct_hash_message(primitive=None, hexstr=None, text=None):
+def defunct_hash_message(
+        *,
+        primitive=None,
+        hexstr=None,
+        text=None,
+        signature_version=b'E',
+        version_specific_data=None):
     '''
     Convert the provided message into a message hash, to be signed.
     This provides the same prefix and hashing approach as
-    :meth:`w3.eth.sign() <web3.eth.Eth.sign>`. That means that the
-    message will automatically be prepended with text
-    defined in EIP-191 as version 'E': ``b'\\x19Ethereum Signed Message:\\n'``
+    :meth:`w3.eth.sign() <web3.eth.Eth.sign>`. The message will by default
+    be prepended with text defined in EIP-191 as
+    version 'E': ``b'\\x19Ethereum Signed Message:\\n'``
     concatenated with the number of bytes in the message.
+    You can also specify the ``signature_version`` as
+        1) version ``0``: Sign data with intended validator (EIP 191)
+           Here the version_specific_data would be a hexstr which is the 20 bytes account address
+        2) version ``1``: Sign the structured data (EIP 712)
+           Here the version_specific_data would be <WIP(Needs to be updated)>
 
     Awkwardly, the number of bytes in the message is encoded in decimal ascii. So
     if the message is 'abcde', then the length is encoded as the ascii
@@ -37,6 +48,8 @@ def defunct_hash_message(primitive=None, hexstr=None, text=None):
     :type primitive: bytes or int
     :param str hexstr: the message encoded as hex
     :param str text: the message as a series of unicode characters (a normal Py3 str)
+    :param bytes signature_version: a byte indicating which kind of prefix is to be added (EIP 191)
+    :param version_specific_data: the data which is needed for adding the prefix (EIP 191)
     :returns: The hash of the message, after adding the prefix
     :rtype: ~hexbytes.main.HexBytes
 
@@ -64,5 +77,12 @@ def defunct_hash_message(primitive=None, hexstr=None, text=None):
         HexBytes('0x1476abb745d423bf09273f1afd887d951181d25adc66c4834a70491911b7f750')
     '''
     message_bytes = to_bytes(primitive, hexstr=hexstr, text=text)
-    recovery_hasher = compose(HexBytes, keccak, signature_wrapper)
+    recovery_hasher = compose(
+        HexBytes,
+        keccak,
+        signature_wrapper(
+            signature_version=signature_version,
+            version_specific_data=version_specific_data,
+        )
+    )
     return recovery_hasher(message_bytes)

--- a/tests/core/test_accounts.py
+++ b/tests/core/test_accounts.py
@@ -322,6 +322,19 @@ def test_eth_account_sign(acct, message, key, expected_bytes, expected_hash, v, 
     assert account.signHash(msghash) == signed
 
 
+def test_eth_account_sign_data_with_intended_validator(acct):
+    account = acct.create()
+    hashed_msg = defunct_hash_message(
+        text="hello world",
+        signature_version=b'\x00',
+        version_specific_data=account.address,
+    )
+    signed = acct.signHash(hashed_msg, account.privateKey)
+
+    new_addr = Account.recoverHash(hashed_msg, signature=signed.signature)
+    assert new_addr == account.address
+
+
 @pytest.mark.parametrize(
     'txn, private_key, expected_raw_tx, tx_hash, r, s, v',
     (


### PR DESCRIPTION
## What was wrong?

`EIP 191` needs to be implemented as part of https://github.com/ethereum/web3.py/issues/1241

## How was it fixed?

* Personal Sign was already implemented.
* Support was added for `signature version 0x00` (Signing `Data with intended validator`) by making `defunct_hash_message` take the `signature_version` and the `version_specific_data` as arguments. Then the `signature_wrapper` function was modified to add support to these `signature versions`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.topbestpics.com/wp-content/uploads/2017/04/cute-baby-hedgehog-cute-animals.jpg)
