### PR TITLE
Make Account.default_kdf private (and release notes)

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -1,6 +1,30 @@
 Release Notes
 =============
 
+v0.4.0
+----------------
+
+Released 2019-04-29
+
+- BREAKING CHANGE: drop python 3.5 (and therefore pypy3 support).
+  `#60 <https://github.com/ethereum/eth-account/pull/60>`_ (includes other housekeeping)
+- New message signing API: :meth:`~eth_account.account.Account.sign_message` and ``recover_message``.
+  `#61 <https://github.com/ethereum/eth-account/pull/61>`_
+
+  - New :meth:`eth_account.messages.encode_intended_validator` for EIP-191's Intended Validator
+    message-signing format.
+    `#56 <https://github.com/ethereum/eth-account/pull/56>`_
+  - New :meth:`eth_account.messages.encode_structured_data` for EIP-712's Structured Data
+    message-signing format.
+    `#57 <https://github.com/ethereum/eth-account/pull/57>`_
+- Add optional param iterations to :meth:`~eth_account.account.Account.encrypt`
+  `#52 <https://github.com/ethereum/eth-account/pull/52>`_
+- Add optional param kdf to :meth:`~eth_account.account.Account.encrypt`, plus env var
+  :envvar:`ETH_ACCOUNT_KDF`. Default kdf switched from hmac-sha256 to scrypt.
+  `#38 <https://github.com/ethereum/eth-account/pull/38>`_
+- Accept "to" addresses formatted as :class:`bytes` in addition to checksummed, hex-encoded.
+  `#36 <https://github.com/ethereum/eth-account/pull/36>`_
+
 v0.3.0
 ----------------
 

--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -144,7 +144,7 @@ class Account(object):
         :returns: The data to use in your encrypted file
         :rtype: dict
 
-        If kdf is not set, the default key deriviation function falls back to the
+        If kdf is not set, the default key derivation function falls back to the
         environment variable :envvar:`ETH_ACCOUNT_KDF`. If that is not set, then
         'scrypt' will be used as the default.
 

--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -58,12 +58,7 @@ class Account(object):
     '''
     _keys = keys
 
-    default_kdf = os.getenv('ETH_ACCOUNT_KDF', 'scrypt')
-    '''
-    The default key deriviation function (KDF) to use when encrypting a private key. If the
-    environment variable :envvar:`ETH_ACCOUNT_KDF` is set, it's value will be used as the default.
-    Otherwise, 'scrypt' will be used as the default.
-    '''
+    _default_kdf = os.getenv('ETH_ACCOUNT_KDF', 'scrypt')
 
     @combomethod
     def create(self, extra_entropy=''):
@@ -149,6 +144,10 @@ class Account(object):
         :returns: The data to use in your encrypted file
         :rtype: dict
 
+        If kdf is not set, the default key deriviation function falls back to the
+        environment variable :envvar:`ETH_ACCOUNT_KDF`. If that is not set, then
+        'scrypt' will be used as the default.
+
         .. code-block:: python
 
             >>> import getpass
@@ -188,7 +187,7 @@ class Account(object):
             key_bytes = HexBytes(private_key)
 
         if kdf is None:
-            kdf = cls.default_kdf
+            kdf = cls._default_kdf
 
         password_bytes = text_if_str(to_bytes, password)
         assert len(key_bytes) == 32

--- a/tests/core/test_accounts.py
+++ b/tests/core/test_accounts.py
@@ -110,7 +110,7 @@ def signature_kwargs(request):
 
 def test_eth_account_default_kdf(acct, monkeypatch):
     assert os.getenv('ETH_ACCOUNT_KDF') is None
-    assert acct.default_kdf == 'scrypt'
+    assert acct._default_kdf == 'scrypt'
 
     monkeypatch.setenv('ETH_ACCOUNT_KDF', 'pbkdf2')
     assert os.getenv('ETH_ACCOUNT_KDF') == 'pbkdf2'
@@ -118,7 +118,7 @@ def test_eth_account_default_kdf(acct, monkeypatch):
     import importlib
     from eth_account import account
     importlib.reload(account)
-    assert account.Account.default_kdf == 'pbkdf2'
+    assert account.Account._default_kdf == 'pbkdf2'
 
 
 def test_eth_account_create_variation(acct):


### PR DESCRIPTION
## What was wrong?

It doesn't seem like we need so many different ways to set a default kdf. An environment variable, and a keyword arg on `encrypt()` seem sufficient.  If we find more use cases, then adding it back as public is a lot easier than removing it later.

Also, added a bunch of release notes ahead of the v0.4.0 release.

## How was it fixed?

- Added `_` in front.
- Moved docs about kdf environment variable into the method where you would find it relevant (`encrypt`).
- Added release notes

I expect a cryptography failure which will be resolved after rebasing on #61 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.imgur.com/p39xN.jpg)