### PR TITLE
Deprecate camel-case

### DIFF
--- a/.project-template/template_vars.txt
+++ b/.project-template/template_vars.txt
@@ -1,6 +1,6 @@
-<MODULE_NAME>
-<PYPI_NAME>
-<REPO_NAME>
-<RTD_NAME>
-<PROJECT_NAME>
-<SHORT_DESCRIPTION>
+eth_account
+eth-account
+eth-account
+eth-account
+eth-account
+Sign Ethereum transactions and messages with local private keys

--- a/eth_account/_utils/signing.py
+++ b/eth_account/_utils/signing.py
@@ -45,7 +45,7 @@ def sign_transaction_dict(eth_key, transaction_dict):
 
 
 def hash_of_signed_transaction(txn_obj):
-    '''
+    """
     Regenerate the hash of the signed transaction object.
 
     1. Infer the chain ID from the signature
@@ -57,7 +57,7 @@ def hash_of_signed_transaction(txn_obj):
     See details at https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md
 
     :return: the hash of the provided transaction, to be signed
-    '''
+    """
     (chain_id, _v) = extract_chain_id(txn_obj.v)
     unsigned_parts = strip_signature(txn_obj)
     if chain_id is None:
@@ -69,10 +69,10 @@ def hash_of_signed_transaction(txn_obj):
 
 
 def extract_chain_id(raw_v):
-    '''
+    """
     Extracts chain ID, according to EIP-155
     @return (chain_id, v)
-    '''
+    """
     above_id_offset = raw_v - CHAIN_ID_OFFSET
     if above_id_offset < 0:
         if raw_v in {0, 1}:

--- a/eth_account/_utils/structured_data/hashing.py
+++ b/eth_account/_utils/structured_data/hashing.py
@@ -93,7 +93,7 @@ def hash_struct_type(primary_type, types):
 
 def is_valid_abi_type(type_name):
     """
-    This function is used to make sure that the ``type_name`` is a valid ABI Type.
+    Determine if the ``type_name`` is a valid ABI Type.
 
     Please note that this is a temporary function and should be replaced by the corresponding
     ABI function, once the following issue has been resolved.

--- a/eth_account/_utils/transactions.py
+++ b/eth_account/_utils/transactions.py
@@ -33,6 +33,8 @@ from .validation import (
     is_valid_address,
 )
 
+VALID_EMPTY_ADDRESSES = {None, b'', ''}
+
 
 def serializable_unsigned_transaction_from_dict(transaction_dict):
     assert_valid_fields(transaction_dict)
@@ -67,7 +69,7 @@ def is_int_or_prefixed_hexstr(val):
 
 
 def is_empty_or_checksum_address(val):
-    if val in {None, b'', ''}:
+    if val in VALID_EMPTY_ADDRESSES:
         return True
     else:
         return is_valid_address(val)

--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -80,16 +80,16 @@ class Account(object):
             >>> acct = Account.create('KEYSMASH FJAFJKLDSKF7JKFDJ 1530')
             >>> acct.address
             '0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E'
-            >>> acct.privateKey
+            >>> acct.key
             b"\\xb2\\}\\xb3\\x1f\\xee\\xd9\\x12''\\xbf\\t9\\xdcv\\x9a\\x96VK-\\xe4\\xc4rm\\x03[6\\xec\\xf1\\xe5\\xb3d"
 
-            # These methods are also available: signHash(), signTransaction(), encrypt()
+            # These methods are also available: sign_message(), sign_transaction(), encrypt()
             # They correspond to the same-named methods in Account.*
             # but without the private key argument
         '''
         extra_key_bytes = text_if_str(to_bytes, extra_entropy)
         key_bytes = keccak(os.urandom(32) + extra_key_bytes)
-        return self.privateKeyToAccount(key_bytes)
+        return self.from_key(key_bytes)
 
     @staticmethod
     def decrypt(keyfile_json, password):
@@ -202,6 +202,18 @@ class Account(object):
     @combomethod
     def privateKeyToAccount(self, private_key):
         '''
+        .. CAUTION:: Deprecated for :meth:`~eth_account.account.Account.from_key`.
+            This method will be removed in v0.5
+        '''
+        warnings.warn(
+            "privateKeyToAccount is deprecated in favor of from_key",
+            category=DeprecationWarning,
+        )
+        return self.from_key(private_key)
+
+    @combomethod
+    def from_key(self, private_key):
+        '''
         Returns a convenient object for working with the given private key.
 
         :param private_key: The raw private key
@@ -211,14 +223,14 @@ class Account(object):
 
         .. code-block:: python
 
-            >>> acct = Account.privateKeyToAccount(
+            >>> acct = Account.from_key(
               0xb25c7db31feed9122727bf0939dc769a96564b2de4c4726d035b36ecf1e5b364)
             >>> acct.address
             '0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E'
-            >>> acct.privateKey
+            >>> acct.key
             b"\\xb2\\}\\xb3\\x1f\\xee\\xd9\\x12''\\xbf\\t9\\xdcv\\x9a\\x96VK-\\xe4\\xc4rm\\x03[6\\xec\\xf1\\xe5\\xb3d"
 
-            # These methods are also available: signHash(), signTransaction(), encrypt()
+            # These methods are also available: sign_message(), sign_transaction(), encrypt()
             # They correspond to the same-named methods in Account.*
             # but without the private key argument
         '''
@@ -327,6 +339,18 @@ class Account(object):
     @combomethod
     def recoverTransaction(self, serialized_transaction):
         '''
+        .. CAUTION:: Deprecated for :meth:`~eth_account.account.Account.recover_transaction`.
+            This method will be removed in v0.5
+        '''
+        warnings.warn(
+            "recoverTransaction is deprecated in favor of recover_transaction",
+            category=DeprecationWarning,
+        )
+        return self.recover_transaction(serialized_transaction)
+
+    @combomethod
+    def recover_transaction(self, serialized_transaction):
+        '''
         Get the address of the account that signed this transaction.
 
         :param serialized_transaction: the complete signed transaction
@@ -337,7 +361,7 @@ class Account(object):
         .. code-block:: python
 
             >>> raw_transaction = '0xf86a8086d55698372431831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008025a009ebb6ca057a0535d6186462bc0b465b561c94a295bdb0621fc19208ab149a9ca0440ffd775ce91a833ab410777204d5341a6f9fa91216a6f3ee2c051fea6a0428',  # noqa: E501
-            >>> Account.recoverTransaction(raw_transaction)
+            >>> Account.recover_transaction(raw_transaction)
             '0x2c7536E3605D9C16a7a3D7b1898e529396a65c23'
         '''
         txn_bytes = HexBytes(serialized_transaction)
@@ -346,6 +370,17 @@ class Account(object):
         return self._recover_hash(msg_hash, vrs=vrs_from(txn))
 
     def setKeyBackend(self, backend):
+        '''
+        .. CAUTION:: Deprecated for :meth:`~eth_account.account.Account.set_key_backend`.
+            This method will be removed in v0.5
+        '''
+        warnings.warn(
+            "setKeyBackend is deprecated in favor of set_key_backend",
+            category=DeprecationWarning,
+        )
+        self.set_key_backend(backend)
+
+    def set_key_backend(self, backend):
         '''
         Change the backend used by the underlying eth-keys library.
 
@@ -447,6 +482,18 @@ class Account(object):
     @combomethod
     def signTransaction(self, transaction_dict, private_key):
         '''
+        .. CAUTION:: Deprecated for :meth:`~eth_account.account.Account.sign_transaction`.
+            This method will be removed in v0.5
+        '''
+        warnings.warn(
+            "signTransaction is deprecated in favor of sign_transaction",
+            category=DeprecationWarning,
+        )
+        return self.sign_transaction(transaction_dict, private_key)
+
+    @combomethod
+    def sign_transaction(self, transaction_dict, private_key):
+        '''
         Sign a transaction using a local private key. Produces signature details
         and the hex-encoded transaction suitable for broadcast using
         :meth:`w3.eth.sendRawTransaction() <web3.eth.Eth.sendRawTransaction>`.
@@ -475,7 +522,7 @@ class Account(object):
                     'chainId': 1
                 }
             >>> key = '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318'
-            >>> signed = Account.signTransaction(transaction, key)
+            >>> signed = Account.sign_transaction(transaction, key)
             {'hash': HexBytes('0x6893a6ee8df79b0f5d64a180cd1ef35d030f3e296a5361cf04d02ce720d32ec5'),
              'r': 4487286261793418179817841024889747115779324305375823110249149479905075174044,
              'rawTransaction': HexBytes('0xf86a8086d55698372431831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008025a009ebb6ca057a0535d6186462bc0b465b561c94a295bdb0621fc19208ab149a9ca0440ffd775ce91a833ab410777204d5341a6f9fa91216a6f3ee2c051fea6a0428'),  # noqa: E501
@@ -486,7 +533,7 @@ class Account(object):
         if not isinstance(transaction_dict, Mapping):
             raise TypeError("transaction_dict must be dict-like, got %r" % transaction_dict)
 
-        account = self.privateKeyToAccount(private_key)
+        account = self.from_key(private_key)
 
         # allow from field, *only* if it matches the private key
         if 'from' in transaction_dict:

--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -56,18 +56,18 @@ from eth_account.signers.local import (
 
 
 class Account(object):
-    '''
-    This is the primary entry point for working with Ethereum private keys.
+    """
+    Account is the primary entry point for working with Ethereum private keys.
 
     It does **not** require a connection to an Ethereum node.
-    '''
+    """
     _keys = keys
 
     _default_kdf = os.getenv('ETH_ACCOUNT_KDF', 'scrypt')
 
     @combomethod
     def create(self, extra_entropy=''):
-        '''
+        r"""
         Creates a new private key, and returns it as a :class:`~eth_account.local.LocalAccount`.
 
         :param extra_entropy: Add extra randomness to whatever randomness your OS can provide
@@ -81,19 +81,19 @@ class Account(object):
             >>> acct.address
             '0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E'
             >>> acct.key
-            b"\\xb2\\}\\xb3\\x1f\\xee\\xd9\\x12''\\xbf\\t9\\xdcv\\x9a\\x96VK-\\xe4\\xc4rm\\x03[6\\xec\\xf1\\xe5\\xb3d"
+            b"\xb2\}\xb3\x1f\xee\xd9\x12''\xbf\t9\xdcv\x9a\x96VK-\xe4\xc4rm\x03[6\xec\xf1\xe5\xb3d"
 
             # These methods are also available: sign_message(), sign_transaction(), encrypt()
             # They correspond to the same-named methods in Account.*
             # but without the private key argument
-        '''
+        """
         extra_key_bytes = text_if_str(to_bytes, extra_entropy)
         key_bytes = keccak(os.urandom(32) + extra_key_bytes)
         return self.from_key(key_bytes)
 
     @staticmethod
     def decrypt(keyfile_json, password):
-        '''
+        """
         Decrypts a private key that was encrypted using an Ethereum client or
         :meth:`~Account.encrypt`.
 
@@ -123,7 +123,7 @@ class Account(object):
             >>> Account.decrypt(encrypted, getpass.getpass())
             HexBytes('0xb25c7db31feed9122727bf0939dc769a96564b2de4c4726d035b36ecf1e5b364')
 
-        '''
+        """
         if isinstance(keyfile_json, str):
             keyfile = json.loads(keyfile_json)
         elif is_dict(keyfile_json):
@@ -135,7 +135,7 @@ class Account(object):
 
     @classmethod
     def encrypt(cls, private_key, password, kdf=None, iterations=None):
-        '''
+        """
         Creates a dictionary with an encrypted version of your private key.
         To import this keyfile into Ethereum clients like geth and parity:
         encode this dictionary with :func:`json.dumps` and save it to disk where your
@@ -185,7 +185,7 @@ class Account(object):
 
              >>> with open('my-keyfile', 'w') as f:
                  f.write(json.dumps(encrypted))
-        '''
+        """
         if isinstance(private_key, keys.PrivateKey):
             key_bytes = private_key.to_bytes()
         else:
@@ -201,10 +201,10 @@ class Account(object):
 
     @combomethod
     def privateKeyToAccount(self, private_key):
-        '''
+        """
         .. CAUTION:: Deprecated for :meth:`~eth_account.account.Account.from_key`.
             This method will be removed in v0.5
-        '''
+        """
         warnings.warn(
             "privateKeyToAccount is deprecated in favor of from_key",
             category=DeprecationWarning,
@@ -213,7 +213,7 @@ class Account(object):
 
     @combomethod
     def from_key(self, private_key):
-        '''
+        r"""
         Returns a convenient object for working with the given private key.
 
         :param private_key: The raw private key
@@ -228,18 +228,18 @@ class Account(object):
             >>> acct.address
             '0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E'
             >>> acct.key
-            b"\\xb2\\}\\xb3\\x1f\\xee\\xd9\\x12''\\xbf\\t9\\xdcv\\x9a\\x96VK-\\xe4\\xc4rm\\x03[6\\xec\\xf1\\xe5\\xb3d"
+            b"\xb2\}\xb3\x1f\xee\xd9\x12''xbf\t9\xdcv\x9a\x96VK-\xe4\xc4rm\x03[6\xec\xf1\xe5\xb3d"
 
             # These methods are also available: sign_message(), sign_transaction(), encrypt()
             # They correspond to the same-named methods in Account.*
             # but without the private key argument
-        '''
+        """
         key = self._parsePrivateKey(private_key)
         return LocalAccount(key, self)
 
     @combomethod
     def recover_message(self, signable_message: SignableMessage, vrs=None, signature=None):
-        '''
+        r"""
         Get the address of the account that signed the given message.
         You must specify exactly one of: vrs or signature
 
@@ -271,7 +271,7 @@ class Account(object):
                   '0x3e5bfbbf4d3e39b1a2fd816a7680c19ebebaf3a141b239934ad43cb33fcec8ce')
             >>> Account.recover_message(message, vrs=vrs)
             >>> vrs = (
-                  b'\\x1c',
+                  b'\x1c',
                   b'\\xe6\\xca\\x9b\\xbaX\\xc8\\x86\\x11\\xfa\\xd6jl\\xe8\\xf9\\x96\\x90\\x81\\x95Y8\\x07\\xc4\\xb3\\x8b\\xd5(\\xd2\\xcf\\xf0\\x9dN\\xb3',  # noqa: E501
                   b'>[\\xfb\\xbfM>9\\xb1\\xa2\\xfd\\x81jv\\x80\\xc1\\x9e\\xbe\\xba\\xf3\\xa1A\\xb29\\x93J\\xd4<\\xb3?\\xce\\xc8\\xce')  # noqa: E501
             >>> Account.recover_message(message, vrs=vrs)
@@ -290,13 +290,13 @@ class Account(object):
             >>> # Caution about this approach: likely problems if there are leading 0s
             >>> signature = 0xe6ca9bba58c88611fad66a6ce8f996908195593807c4b38bd528d2cff09d4eb33e5bfbbf4d3e39b1a2fd816a7680c19ebebaf3a141b239934ad43cb33fcec8ce1c  # noqa: E501
             >>> Account.recover_message(message, signature=signature)
-        '''
+        """
         message_hash = _hash_eip191_message(signable_message)
         return self._recover_hash(message_hash, vrs, signature)
 
     @combomethod
     def recoverHash(self, message_hash, vrs=None, signature=None):
-        '''
+        """
         Get the address of the account that signed the message with the given hash.
         You must specify exactly one of: vrs or signature
 
@@ -311,7 +311,7 @@ class Account(object):
         :type signature: hex str or bytes or int
         :returns: address of signer, hex-encoded & checksummed
         :rtype: str
-        '''
+        """
         warnings.warn(
             "recoverHash is deprecated in favor of recover_message",
             category=DeprecationWarning,
@@ -338,10 +338,10 @@ class Account(object):
 
     @combomethod
     def recoverTransaction(self, serialized_transaction):
-        '''
+        """
         .. CAUTION:: Deprecated for :meth:`~eth_account.account.Account.recover_transaction`.
             This method will be removed in v0.5
-        '''
+        """
         warnings.warn(
             "recoverTransaction is deprecated in favor of recover_transaction",
             category=DeprecationWarning,
@@ -350,7 +350,7 @@ class Account(object):
 
     @combomethod
     def recover_transaction(self, serialized_transaction):
-        '''
+        """
         Get the address of the account that signed this transaction.
 
         :param serialized_transaction: the complete signed transaction
@@ -363,17 +363,17 @@ class Account(object):
             >>> raw_transaction = '0xf86a8086d55698372431831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008025a009ebb6ca057a0535d6186462bc0b465b561c94a295bdb0621fc19208ab149a9ca0440ffd775ce91a833ab410777204d5341a6f9fa91216a6f3ee2c051fea6a0428',  # noqa: E501
             >>> Account.recover_transaction(raw_transaction)
             '0x2c7536E3605D9C16a7a3D7b1898e529396a65c23'
-        '''
+        """
         txn_bytes = HexBytes(serialized_transaction)
         txn = Transaction.from_bytes(txn_bytes)
         msg_hash = hash_of_signed_transaction(txn)
         return self._recover_hash(msg_hash, vrs=vrs_from(txn))
 
     def setKeyBackend(self, backend):
-        '''
+        """
         .. CAUTION:: Deprecated for :meth:`~eth_account.account.Account.set_key_backend`.
             This method will be removed in v0.5
-        '''
+        """
         warnings.warn(
             "setKeyBackend is deprecated in favor of set_key_backend",
             category=DeprecationWarning,
@@ -381,7 +381,7 @@ class Account(object):
         self.set_key_backend(backend)
 
     def set_key_backend(self, backend):
-        '''
+        """
         Change the backend used by the underlying eth-keys library.
 
         *(The default is fine for most users)*
@@ -389,12 +389,12 @@ class Account(object):
         :param backend: any backend that works in
             `eth_keys.KeyApi(backend) <https://github.com/ethereum/eth-keys/#keyapibackendnone>`_
 
-        '''
+        """
         self._keys = KeyAPI(backend)
 
     @combomethod
     def sign_message(self, signable_message: SignableMessage, private_key):
-        r'''
+        r"""
         Sign the provided message.
 
         This API supports any messaging format that will encode to EIP-191_ messages.
@@ -430,13 +430,13 @@ class Account(object):
              'v': 28}
 
         .. _EIP-191: https://eips.ethereum.org/EIPS/eip-191
-        '''
+        """
         message_hash = _hash_eip191_message(signable_message)
         return self._sign_hash(message_hash, private_key)
 
     @combomethod
     def signHash(self, message_hash, private_key):
-        '''
+        """
         .. WARNING:: *Never* sign a hash that you didn't generate,
             it can be an arbitrary transaction. For example, it might
             send all of your account's ether to an attacker.
@@ -455,7 +455,7 @@ class Account(object):
         :returns: Various details about the signature - most
           importantly the fields: v, r, and s
         :rtype: ~eth_account.datastructures.AttributeDict
-        '''
+        """
         warnings.warn(
             "signHash is deprecated in favor of sign_message",
             category=DeprecationWarning,
@@ -481,10 +481,10 @@ class Account(object):
 
     @combomethod
     def signTransaction(self, transaction_dict, private_key):
-        '''
+        """
         .. CAUTION:: Deprecated for :meth:`~eth_account.account.Account.sign_transaction`.
             This method will be removed in v0.5
-        '''
+        """
         warnings.warn(
             "signTransaction is deprecated in favor of sign_transaction",
             category=DeprecationWarning,
@@ -493,7 +493,7 @@ class Account(object):
 
     @combomethod
     def sign_transaction(self, transaction_dict, private_key):
-        '''
+        """
         Sign a transaction using a local private key. Produces signature details
         and the hex-encoded transaction suitable for broadcast using
         :meth:`w3.eth.sendRawTransaction() <web3.eth.Eth.sendRawTransaction>`.
@@ -529,7 +529,7 @@ class Account(object):
              's': 30785525769477805655994251009256770582792548537338581640010273753578382951464,
              'v': 37}
             >>> w3.eth.sendRawTransaction(signed.rawTransaction)
-        '''
+        """
         if not isinstance(transaction_dict, Mapping):
             raise TypeError("transaction_dict must be dict-like, got %r" % transaction_dict)
 
@@ -567,7 +567,7 @@ class Account(object):
 
     @combomethod
     def _parsePrivateKey(self, key):
-        '''
+        """
         Generate a :class:`eth_keys.datatypes.PrivateKey` from the provided key. If the
         key is already of type :class:`eth_keys.datatypes.PrivateKey`, return the key.
 
@@ -575,7 +575,7 @@ class Account(object):
                     will be generated
         :type key: hex str, bytes, int or :class:`eth_keys.datatypes.PrivateKey`
         :returns: the provided key represented as a :class:`eth_keys.datatypes.PrivateKey`
-        '''
+        """
         if isinstance(key, self._keys.PrivateKey):
             return key
 

--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -57,7 +57,7 @@ from eth_account.signers.local import (
 
 class Account(object):
     """
-    Account is the primary entry point for working with Ethereum private keys.
+    The primary entry point for working with Ethereum private keys.
 
     It does **not** require a connection to an Ethereum node.
     """

--- a/eth_account/datastructures.py
+++ b/eth_account/datastructures.py
@@ -4,12 +4,12 @@ from attrdict import (
 
 
 class AttributeDict(AttrDict):
-    '''
+    """
     See `AttrDict docs <https://github.com/bcj/AttrDict#attrdict-1>`_
 
     This class differs only in that it is made immutable. This immutability
     is **not** a security guarantee. It is only a style-check convenience.
-    '''
+    """
     def __setitem__(self, attr, val):
         raise TypeError(
             'This data is immutable -- create a copy instead of modifying. '

--- a/eth_account/messages.py
+++ b/eth_account/messages.py
@@ -156,7 +156,7 @@ def encode_defunct(
         *,
         hexstr: str = None,
         text: str = None) -> SignableMessage:
-    r'''
+    r"""
     Encode a message for signing, using an old, unrecommended approach.
 
     Only use this method if you must have compatibility with
@@ -200,7 +200,7 @@ def encode_defunct(
 
         >>> encode_defunct(0x49e299a55346)
         SignableMessage(version=b'E', header=b'thereum Signed Message:\n6', body=b'I\xe2\x99\xa5SF')
-    '''
+    """
     message_bytes = to_bytes(primitive, hexstr=hexstr, text=text)
     msg_length = str(len(message_bytes)).encode('utf-8')
 
@@ -217,7 +217,7 @@ def defunct_hash_message(
         *,
         hexstr: str = None,
         text: str = None) -> HexBytes:
-    '''
+    """
     Convert the provided message into a message hash, to be signed.
 
     .. CAUTION:: Intented for use with the deprecated :meth:`eth_account.account.Account.signHash`.
@@ -229,7 +229,7 @@ def defunct_hash_message(
     :param str hexstr: the message encoded as hex
     :param str text: the message as a series of unicode characters (a normal Py3 str)
     :returns: The hash of the message, after adding the prefix
-    '''
+    """
     signable = encode_defunct(primitive, hexstr=hexstr, text=text)
     hashed = _hash_eip191_message(signable)
     return HexBytes(hashed)

--- a/eth_account/signers/base.py
+++ b/eth_account/signers/base.py
@@ -56,7 +56,15 @@ class BaseAccount(ABC):
     @abstractmethod
     def signTransaction(self, transaction_dict):
         '''
-        Sign a transaction, as in :meth:`~eth_account.account.Account.signTransaction`
+        .. CAUTION:: Deprecated for :meth:`~eth_account.account.signers.local.sign_transaction`.
+            This method will be removed in v0.5
+        '''
+        pass
+
+    @abstractmethod
+    def sign_transaction(self, transaction_dict):
+        '''
+        Sign a transaction, as in :meth:`~eth_account.account.Account.sign_transaction`
         but without specifying the private key.
 
         :param dict transaction_dict: transaction with all fields specified

--- a/eth_account/signers/base.py
+++ b/eth_account/signers/base.py
@@ -9,15 +9,15 @@ from eth_account.messages import (
 
 
 class BaseAccount(ABC):
-    '''
+    """
     Abstract class that defines a collection of convenience methods
     to sign transactions and message hashes.
-    '''
+    """
 
     @property
     @abstractmethod
     def address(self):
-        '''
+        """
         The checksummed public address for this account.
 
         .. code-block:: python
@@ -25,24 +25,24 @@ class BaseAccount(ABC):
             >>> my_account.address
             "0xF0109fC8DF283027b6285cc889F5aA624EaC1F55"
 
-        '''
+        """
         pass
 
     @abstractmethod
     def sign_message(self, signable_message: SignableMessage):
-        '''
+        """
         Sign the EIP-191_ message, as in :meth:`~eth_account.account.Account.sign_message`
         but without specifying the private key.
 
         :param signable_message: The encoded message, ready for signing
 
         .. _EIP-191: https://eips.ethereum.org/EIPS/eip-191
-        '''
+        """
         pass
 
     @abstractmethod
     def signHash(self, message_hash):
-        '''
+        """
         Sign the hash of a message, as in :meth:`~eth_account.account.Account.signHash`
         but without specifying the private key.
 
@@ -50,34 +50,34 @@ class BaseAccount(ABC):
             To be removed in v0.5
 
         :param bytes message_hash: 32 byte hash of the message to sign
-        '''
+        """
         pass
 
     @abstractmethod
     def signTransaction(self, transaction_dict):
-        '''
+        """
         .. CAUTION:: Deprecated for :meth:`~eth_account.account.signers.local.sign_transaction`.
             This method will be removed in v0.5
-        '''
+        """
         pass
 
     @abstractmethod
     def sign_transaction(self, transaction_dict):
-        '''
+        """
         Sign a transaction, as in :meth:`~eth_account.account.Account.sign_transaction`
         but without specifying the private key.
 
         :param dict transaction_dict: transaction with all fields specified
-        '''
+        """
         pass
 
     def __eq__(self, other):
-        '''
+        """
         Equality test between two accounts.
 
         Two accounts are considered the same if they are exactly the same type,
         and can sign for the same address.
-        '''
+        """
         return type(self) == type(other) and self.address == other.address
 
     def __hash__(self):

--- a/eth_account/signers/local.py
+++ b/eth_account/signers/local.py
@@ -6,7 +6,7 @@ from eth_account.signers.base import (
 
 
 class LocalAccount(BaseAccount):
-    '''
+    r"""
     A collection of convenience methods to sign and encrypt, with an embedded private key.
 
     :var bytes key: the 32-byte private key data
@@ -16,7 +16,7 @@ class LocalAccount(BaseAccount):
         >>> my_local_account.address
         "0xF0109fC8DF283027b6285cc889F5aA624EaC1F55"
         >>> my_local_account.key
-        b"\\x01\\x23..."
+        b"\x01\x23..."
 
     You can also get the private key by casting the account to :class:`bytes`:
 
@@ -24,12 +24,12 @@ class LocalAccount(BaseAccount):
 
         >>> bytes(my_local_account)
         b"\\x01\\x23..."
-    '''
+    """
     def __init__(self, key, account):
-        '''
+        """
         :param eth_keys.PrivateKey key: to prefill in private key execution
         :param ~eth_account.account.Account account: the key-unaware management API
-        '''
+        """
         self._publicapi = account
 
         self._address = key.public_key.to_checksum_address()
@@ -45,10 +45,10 @@ class LocalAccount(BaseAccount):
 
     @property
     def privateKey(self):
-        '''
+        """
         .. CAUTION:: Deprecated for :var:`~eth_account.signers.local.LocalAccount.key`.
             This attribute will be removed in v0.5
-        '''
+        """
         warnings.warn(
             "privateKey is deprecated in favor of key",
             category=DeprecationWarning,
@@ -57,16 +57,16 @@ class LocalAccount(BaseAccount):
 
     @property
     def key(self):
-        '''
+        """
         Get the private key.
-        '''
+        """
         return self._private_key
 
     def encrypt(self, password, kdf=None, iterations=None):
-        '''
+        """
         Generate a string with the encrypted key, as in
         :meth:`~eth_account.account.Account.encrypt`, but without a private key argument.
-        '''
+        """
         return self._publicapi.encrypt(self.key, password, kdf=kdf, iterations=iterations)
 
     def signHash(self, message_hash):
@@ -76,10 +76,10 @@ class LocalAccount(BaseAccount):
         )
 
     def sign_message(self, signable_message):
-        '''
+        """
         Generate a string with the encrypted key, as in
         :meth:`~eth_account.account.Account.sign_message`, but without a private key argument.
-        '''
+        """
         return self._publicapi.sign_message(signable_message, private_key=self.key)
 
     def signTransaction(self, transaction_dict):

--- a/tests/core/test_structured_data_signing.py
+++ b/tests/core/test_structured_data_signing.py
@@ -152,9 +152,8 @@ def test_hashed_structured_data(message_encodings):
 def test_signature_verification(message_encodings):
     account = Account.create()
     structured_msg = encode_structured_data(**message_encodings)
-    hashed_structured_msg = _hash_eip191_message(structured_msg)
-    signed = Account.signHash(hashed_structured_msg, account.privateKey)
-    new_addr = Account.recoverHash(hashed_structured_msg, signature=signed.signature)
+    signed = Account.sign_message(structured_msg, account.key)
+    new_addr = Account.recover_message(structured_msg, signature=signed.signature)
     assert new_addr == account.address
 
 
@@ -163,11 +162,10 @@ def test_signature_variables(message_encodings):
     # mentioned in the EIP. The link is as follows
     # https://github.com/ethereum/EIPs/blob/master/assets/eip-712/Example.js
     structured_msg = encode_structured_data(**message_encodings)
-    hashed_structured_msg = _hash_eip191_message(structured_msg)
     privateKey = keccak(text="cow")
-    acc = Account.privateKeyToAccount(privateKey)
+    acc = Account.from_key(privateKey)
     assert HexBytes(acc.address) == HexBytes("0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826")
-    sig = Account.signHash(hashed_structured_msg, privateKey)
+    sig = Account.sign_message(structured_msg, privateKey)
     assert sig.v == 28
     assert hex(sig.r) == "0x4355c47d63924e8a72e509b65029052eb6c299d53a04e167c5775fd466751c9d"
     assert hex(sig.s) == "0x7299936d304c153f6443dfa05f40ff007d72911b6f72307f996231605b91562"

--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -60,9 +60,9 @@ TEST_PRIVATE_KEY = b'\0' * 31 + b'\x01'
 )
 def test_invalid_transaction_fields(txn_dict, bad_fields):
     if not bad_fields:
-        Account.signTransaction(txn_dict, TEST_PRIVATE_KEY)
+        Account.sign_transaction(txn_dict, TEST_PRIVATE_KEY)
     else:
         with pytest.raises(TypeError) as excinfo:
-            Account.signTransaction(txn_dict, TEST_PRIVATE_KEY)
+            Account.sign_transaction(txn_dict, TEST_PRIVATE_KEY)
         for field in bad_fields:
             assert field in str(excinfo.value)

--- a/tox.ini
+++ b/tox.ini
@@ -39,4 +39,4 @@ extras=lint
 commands=
     flake8 {toxinidir}/eth_account {toxinidir}/tests
     isort --recursive --check-only --diff {toxinidir}/eth_account {toxinidir}/tests
-    pydocstyle {toxinidir}/<MODULE_NAME> {toxinidir}/tests
+    pydocstyle {toxinidir}/eth_account {toxinidir}/tests


### PR DESCRIPTION
## What was wrong?

There are camelCase APIs on eth-account, plus some names that are longer than they need to be.

## How was it fixed?

Deprecated old methods, added snake case methods. Shortened a few:

- `Account.privateKeyToAccount()' -> 'Account.from_key()'
- `LocalAccount.privateKey` -> `LocalAccount.key`

Also, fixed the pydocstyle run, and resolved all the related warnings.

This is blocked on merging #61 . Only the last two commits are not part of #61: 
- 54b8033
- 1b8979c

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/02/81/9c/02819c18e96b26e2a6e2b82c30000a46.jpg)
