### PR TITLE
Use is_encodable_type

### DIFF
--- a/tests/core/test_structured_data_signing.py
+++ b/tests/core/test_structured_data_signing.py
@@ -2,6 +2,9 @@ import json
 import pytest
 import re
 
+from eth_abi.exceptions import (
+    ABITypeError,
+)
 from eth_utils import (
     ValidationError,
     keccak,
@@ -233,9 +236,9 @@ def test_invalid_structured_data_invalid_abi_type():
         "tests/fixtures/invalid_message_invalid_abi_type.json"
     ).read()
     invalid_structured_data = json.loads(invalid_structured_data_string)
-    with pytest.raises(TypeError) as e:
+    with pytest.raises(ABITypeError) as e:
         hash_message(invalid_structured_data)
-    assert str(e.value) == "Received Invalid type `uint25689` in the struct `Person`"
+    assert "'uint25689': integer size out of bounds" in str(e.value)
 
 
 def test_structured_data_invalid_identifier_filtered_by_abi_encodable_function():

--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -4,6 +4,9 @@ from cytoolz import (
     assoc,
     dissoc,
 )
+from eth_abi.exceptions import (
+    ABITypeError,
+)
 
 from eth_account import (
     Account,
@@ -62,7 +65,7 @@ def test_invalid_transaction_fields(txn_dict, bad_fields):
     if not bad_fields:
         Account.sign_transaction(txn_dict, TEST_PRIVATE_KEY)
     else:
-        with pytest.raises(TypeError) as excinfo:
+        with pytest.raises((TypeError, ABITypeError)) as excinfo:
             Account.sign_transaction(txn_dict, TEST_PRIVATE_KEY)
         for field in bad_fields:
             assert field in str(excinfo.value)


### PR DESCRIPTION
## What was wrong?
Replace `is_valid_abi_type` with `is_encodable_type` from `eth-abi` when Python 3.5 support was dropped from this repository

Fixes Issue #59

#### Cute Animal Picture
![baby tiger](https://dingo.care2.com/pictures/causes/3185/3184678.large.jpg)