### PR TITLE
Replace attrdict with NamedTuple

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,28 +61,7 @@ logs
 ### JetBrains template
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
-
-# User-specific stuff:
-.idea/workspace.xml
-.idea/tasks.xml
-.idea/dictionaries
-.idea/vcs.xml
-.idea/jsLibraryMappings.xml
-
-# Sensitive or high-churn files:
-.idea/dataSources.ids
-.idea/dataSources.xml
-.idea/dataSources.local.xml
-.idea/sqlDataSources.xml
-.idea/dynamic.xml
-.idea/uiDesigner.xml
-
-# Gradle:
-.idea/gradle.xml
-.idea/libraries
-
-# Mongo Explorer plugin:
-.idea/mongoSettings.xml
+.idea
 
 # VIM temp files
 *.swp

--- a/docs/eth_account.rst
+++ b/docs/eth_account.rst
@@ -10,7 +10,7 @@ Account
 
 See :doc:`eth_account.signers` for alternative signers.
 
-AttributeDict
+SignedTransaction & SignedMessage
 -----------------------------------
 
 .. automodule:: eth_account.datastructures

--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -44,7 +44,8 @@ from eth_account._utils.transactions import (
     vrs_from,
 )
 from eth_account.datastructures import (
-    AttributeDict,
+    SignedMessage,
+    SignedTransaction,
 )
 from eth_account.hdaccount import (
     ETHEREUM_DEFAULT_PATH,
@@ -517,7 +518,7 @@ class Account(object):
         :param private_key: the key to sign the message with
         :type private_key: hex str, bytes, int or :class:`eth_keys.datatypes.PrivateKey`
         :returns: Various details about the signature - most importantly the fields: v, r, and s
-        :rtype: ~eth_account.datastructures.AttributeDict
+        :rtype: ~eth_account.datastructures.SignedMessage
 
         .. doctest:: python
 
@@ -531,12 +532,13 @@ class Account(object):
             >>> # If you're curious about the internal fields of SignableMessage, take a look at EIP-191, linked above  # noqa: E501
             >>> key = "0xb25c7db31feed9122727bf0939dc769a96564b2de4c4726d035b36ecf1e5b364"
             >>> Account.sign_message(msghash, key)
-            AttrDict({'messageHash':
-             HexBytes('0x1476abb745d423bf09273f1afd887d951181d25adc66c4834a70491911b7f750'),
-             'r': 104389933075820307925104709181714897380569894203213074526835978196648170704563,
-             's': 28205917190874851400050446352651915501321657673772411533993420917949420456142,
-             'v': 28,
-             'signature': HexBytes('...')})
+            SignedMessage(messageHash=HexBytes('0x1476abb745d423bf09273f1afd887d951181d25adc66c4834a70491911b7f750'),
+             r=104389933075820307925104709181714897380569894203213074526835978196648170704563,
+             s=28205917190874851400050446352651915501321657673772411533993420917949420456142,
+             v=28,
+             signature=HexBytes('0xe6ca9bba58c88611fad66a6ce8f996908195593807c4b38bd528d2cff09d4eb33e5bfbbf4d3e39b1a2fd816a7680c19ebebaf3a141b239934ad43cb33fcec8ce1c'))
+
+
 
         .. _EIP-191: https://eips.ethereum.org/EIPS/eip-191
         """
@@ -563,7 +565,7 @@ class Account(object):
         :type private_key: hex str, bytes, int or :class:`eth_keys.datatypes.PrivateKey`
         :returns: Various details about the signature - most
           importantly the fields: v, r, and s
-        :rtype: ~eth_account.datastructures.AttributeDict
+        :rtype: ~eth_account.datastructures.SignedMessage
         """
         warnings.warn(
             "signHash is deprecated in favor of sign_message",
@@ -580,13 +582,13 @@ class Account(object):
         key = self._parsePrivateKey(private_key)
 
         (v, r, s, eth_signature_bytes) = sign_message_hash(key, msg_hash_bytes)
-        return AttributeDict({
-            'messageHash': msg_hash_bytes,
-            'r': r,
-            's': s,
-            'v': v,
-            'signature': HexBytes(eth_signature_bytes),
-        })
+        return SignedMessage(
+            messageHash=msg_hash_bytes,
+            r=r,
+            s=s,
+            v=v,
+            signature=HexBytes(eth_signature_bytes),
+        )
 
     @combomethod
     def signTransaction(self, transaction_dict, private_key):
@@ -666,13 +668,13 @@ class Account(object):
 
         transaction_hash = keccak(rlp_encoded)
 
-        return AttributeDict({
-            'rawTransaction': HexBytes(rlp_encoded),
-            'hash': HexBytes(transaction_hash),
-            'r': r,
-            's': s,
-            'v': v,
-        })
+        return SignedTransaction(
+            rawTransaction=HexBytes(rlp_encoded),
+            hash=HexBytes(transaction_hash),
+            r=r,
+            s=s,
+            v=v,
+        )
 
     @combomethod
     def _parsePrivateKey(self, key):

--- a/eth_account/datastructures.py
+++ b/eth_account/datastructures.py
@@ -1,28 +1,36 @@
-from attrdict import (
-    AttrDict,
+from typing import (
+    NamedTuple,
+)
+
+from hexbytes import (
+    HexBytes,
 )
 
 
-class AttributeDict(AttrDict):
-    """
-    See `AttrDict docs <https://github.com/bcj/AttrDict#attrdict-1>`_
+def __getitem__(self, index):
+    try:
+        return tuple.__getitem__(self, index)
+    except TypeError:
+        return getattr(self, index)
 
-    This class differs only in that it is made immutable. This immutability
-    is **not** a security guarantee. It is only a style-check convenience.
-    """
-    def __setitem__(self, attr, val):
-        raise TypeError(
-            'This data is immutable -- create a copy instead of modifying. '
-            'For example, AttributeDict(old, replace_key=replace_val).'
-        )
 
-    def _repr_pretty_(self, builder, cycle):
-        """
-        Custom pretty output for the IPython console
-        """
-        builder.text(self.__class__.__name__ + "(")
-        if cycle:
-            builder.text("<cycle>")
-        else:
-            builder.pretty(dict(self))
-        builder.text(")")
+class SignedTransaction(NamedTuple):
+    rawTransaction: HexBytes
+    hash: HexBytes
+    r: int
+    s: int
+    v: int
+
+    def __getitem__(self, index):
+        return __getitem__(self, index)
+
+
+class SignedMessage(NamedTuple):
+    messageHash: HexBytes
+    r: int
+    s: int
+    v: int
+    signature: HexBytes
+
+    def __getitem__(self, index):
+        return __getitem__(self, index)

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
     url='https://github.com/ethereum/eth-account',
     include_package_data=True,
     install_requires=[
-        "attrdict>=2.0.0,<3",
         "bitarray>=1.2.1,<1.3.0",
         "eth-abi>=2.0.0b7,<3",
         "eth-keyfile>=0.5.0,<0.6.0",

--- a/tests/core/test_accounts.py
+++ b/tests/core/test_accounts.py
@@ -300,7 +300,6 @@ def test_sign_message_against_sign_hash_as_text(keyed_acct, message_text):
     # sign via message
     signable_message = encode_defunct(text=message_text)
     signed_via_message = keyed_acct.sign_message(signable_message)
-
     assert signed_via_hash == signed_via_message
 
 
@@ -374,11 +373,11 @@ def test_sign_message_against_sign_hash_as_hex(keyed_acct, message_bytes):
 def test_eth_account_sign(acct, message, key, expected_bytes, expected_hash, v, r, s, signature):
     signable = encode_defunct(text=message)
     signed = acct.sign_message(signable, private_key=key)
-    assert signed.messageHash == expected_hash
-    assert signed.v == v
-    assert signed.r == r
-    assert signed.s == s
-    assert signed.signature == signature
+    assert signed.messageHash == signed['messageHash'] == expected_hash
+    assert signed.v == signed['v'] == v
+    assert signed.r == signed['r'] == r
+    assert signed.s == signed['s'] == s
+    assert signed.signature == signed['signature'] == signature
 
     account = acct.from_key(key)
     assert account.sign_message(signable) == signed
@@ -481,11 +480,11 @@ def test_eth_long_account_address_sign_data_with_intended_validator(acct, messag
 )
 def test_eth_account_sign_transaction(acct, txn, private_key, expected_raw_tx, tx_hash, r, s, v):
     signed = acct.sign_transaction(txn, private_key)
-    assert signed.r == r
-    assert signed.s == s
-    assert signed.v == v
-    assert signed.rawTransaction == expected_raw_tx
-    assert signed.hash == tx_hash
+    assert signed.r == signed['r'] == r
+    assert signed.s == signed['s'] == s
+    assert signed.v == signed['v'] == v
+    assert signed.rawTransaction == signed['rawTransaction'] == expected_raw_tx
+    assert signed.hash == signed['hash'] == tx_hash
 
     account = acct.from_key(private_key)
     assert account.sign_transaction(txn) == signed


### PR DESCRIPTION
## What was wrong?

The usage of `attrdict` dependency was causing a deprecation warning.

```
  from collections import (
/home/cburgdorf/Documents/hacking/ef/trinity/venv/lib/python3.7/site-packages/attrdict/mixins.py:5: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working

```

## How was it fixed?

Replaced with `NamedTuple` which should have the positive side effect of a stronger guarantee of immutability.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/cc/c6/b7/ccc6b772bd666ac542eb1aec7cc74606.jpg)
