### PR TITLE
Reduces the number of pbkdf2 iteration to speed up tests

### DIFF
--- a/newsfragments/77.performance.rst
+++ b/newsfragments/77.performance.rst
@@ -1,0 +1,1 @@
+Reduce the number of pbkdf2 iterations to speed up tests

--- a/tests/core/test_accounts.py
+++ b/tests/core/test_accounts.py
@@ -645,7 +645,7 @@ def get_encrypt_test_params():
             private_key,
             password,
             None,
-            None,
+            2,
             private_key.to_bytes(),
             'scrypt'
         ),
@@ -653,7 +653,7 @@ def get_encrypt_test_params():
             key,
             password,
             'pbkdf2',
-            None,
+            4,
             key_bytes,
             'pbkdf2'
         ),
@@ -661,7 +661,7 @@ def get_encrypt_test_params():
             key,
             password,
             None,
-            1024,
+            8,
             key_bytes,
             'scrypt'
         ),
@@ -669,7 +669,7 @@ def get_encrypt_test_params():
             key,
             password,
             'pbkdf2',
-            1024,
+            16,
             key_bytes,
             'pbkdf2'
         ),
@@ -677,7 +677,7 @@ def get_encrypt_test_params():
             key,
             password,
             'scrypt',
-            1024,
+            32,
             key_bytes,
             'scrypt'
         ),


### PR DESCRIPTION
Divides test runtime by 2.

## What was wrong?

Running tests take a bit long.

## How was it fixed?

Reducing the pbkdf2 iterations in the `get_encrypt_test_params()` fixture.
This is a first quick fix, but I feel like the `test_eth_account_encrypt()` test may require a little refactor to quite all the branching it contains.

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/24973/71533449-fe335980-28f8-11ea-8518-4dc9b4bf480d.png)
