### PR TITLE
Setup coverage testing via pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ lint-roll:
 	$(MAKE) lint
 
 test:
-	pytest tests
+	pytest tests --cov eth_account/
 
 test-all:
 	tox

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ extras_require = {
         "hypothesis>=4.18.0,<5",
         "pytest>=4.4.0,<5",
         "pytest-xdist",
+        "pytest-cov",
         "tox>=2.9.1,<3",
     ],
     'lint': [

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ ignore=
 [testenv]
 usedevelop=True
 commands=
-    core: pytest {posargs:tests/core}
+    core: pytest --cov eth_account/ {posargs:tests/core}
     doctest: make -C {toxinidir}/docs doctest
 basepython =
     doctest: python


### PR DESCRIPTION
Follow-up PR can publish it to coveralls.io for better tracking.
Note that current coverage is 88%.

## What was wrong?

We currently have no track of the library coverage.

## How was it fixed?

Simply adding `pytest-cov` test dependency and adding the `--cov` flag when `pytest` is ran.

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/24973/71534224-a0edd700-28fd-11ea-8dba-fb8eefc5064c.png)
