### PR TITLE
Fix typo in SignableMessage docstring

### DIFF
--- a/eth_account/messages.py
+++ b/eth_account/messages.py
@@ -47,7 +47,7 @@ class SignableMessage(NamedTuple):
 
         - :meth:`encode_structured_data`
         - :meth:`encode_intended_validator`
-        - :meth:`encode_structured_data`
+        - :meth:`encode_defunct`
 
     .. _EIP-191: https://eips.ethereum.org/EIPS/eip-191
     """


### PR DESCRIPTION
## What was wrong?
I was trying to wrap my head around the EIPs about signing messages and found a small typo in the SignableMessage docstring. Probably meant to refer to the third method of encoding: `encode_defunct`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.fillgap.news/wp-content/uploads/2017/07/tmg-article_tall-6.jpg)
