### PR TITLE
Fixes encrypt(), decrypt() and messages encode_defunct() doctests

### DIFF
--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -108,19 +108,19 @@ class Account(object):
             >>> encrypted = {
             ... 'address': '5ce9454909639d2d17a3f753ce7d93fa0b9ab12e',
             ... 'crypto': {'cipher': 'aes-128-ctr',
-            ...  'cipherparams': {'iv': '78f214584844e0b241b433d7c3bb8d5f'},
-            ...  'ciphertext': 'd6dbb56e4f54ba6db2e8dc14df17cb7352fdce03681dd3f90ce4b6c1d5af2c4f',
-            ...  'kdf': 'pbkdf2',
-            ...  'kdfparams': {'c': 1000000,
-            ...   'dklen': 32,
-            ...   'prf': 'hmac-sha256',
-            ...   'salt': '45cf943b4de2c05c2c440ef96af914a2'},
-            ...  'mac': 'f5e1af09df5ded25c96fcf075ada313fb6f79735a914adc8cb02e8ddee7813c3'},
+            ...  'cipherparams': {'iv': '482ef54775b0cc59f25717711286f5c8'},
+            ...  'ciphertext': 'cb636716a9fd46adbb31832d964df2082536edd5399a3393327dc89b0193a2be',
+            ...  'kdf': 'scrypt',
+            ...  'kdfparams': {},
+            ...  'kdfparams': {'dklen': 32,
+            ...                'n': 262144,
+            ...                'p': 8,
+            ...                'r': 1,
+            ...                'salt': 'd3c9a9945000fcb6c9df0f854266d573'},
+            ...  'mac': '4f626ec5e7fea391b2229348a65bfef532c2a4e8372c0a6a814505a350a7689d'},
             ... 'id': 'b812f3f9-78cc-462a-9e89-74418aa27cb0',
             ... 'version': 3}
-
-            >>> import getpass
-            >>> Account.decrypt(encrypted, getpass.getpass()) # doctest: +SKIP
+            >>> Account.decrypt(encrypted, 'password')
             HexBytes('0xb25c7db31feed9122727bf0939dc769a96564b2de4c4726d035b36ecf1e5b364')
 
         """
@@ -155,32 +155,25 @@ class Account(object):
 
         .. code-block:: python
 
-            >>> import getpass
-            >>> encrypted = Account.encrypt( # doctest: +SKIP
+            >>> from pprint import pprint
+            >>> encrypted = Account.encrypt(
             ...     0xb25c7db31feed9122727bf0939dc769a96564b2de4c4726d035b36ecf1e5b364,
-            ...     getpass.getpass()
+            ...     'password'
             ... )
-            {
-                'address': '5ce9454909639d2d17a3f753ce7d93fa0b9ab12e',
-                'crypto': {
-                    'cipher': 'aes-128-ctr',
-                    'cipherparams': {
-                        'iv': '0b7845a5c3597d3d378bde9b7c7319b7'
-                    },
-                    'ciphertext': 'a494f1feb3c854e99c1ff01e6aaa17d43c0752009073503b908457dc8de5d2a5',  # noqa: E501
-                    'kdf': 'scrypt',
-                    'kdfparams': {
-                        'dklen': 32,
-                        'n': 262144,
-                        'p': 8,
-                        'r': 1,
-                        'salt': '13c4a48123affaa29189e9097726c698'
-                    },
-                    'mac': 'f4cfb027eb0af9bd7a320b4374a3fa7bef02cfbafe0ec5d1fd7ad129401de0b1'
-                },
-                'id': 'a60e0578-0e5b-4a75-b991-d55ec6451a6f',
-                'version': 3
-            }
+            >>> pprint(encrypted)
+            {'address': '5ce9454909639d2d17a3f753ce7d93fa0b9ab12e',
+             'crypto': {'cipher': 'aes-128-ctr',
+                        'cipherparams': {'iv': '...'},
+                        'ciphertext': '...',
+                        'kdf': 'scrypt',
+                        'kdfparams': {'dklen': 32,
+                                      'n': 262144,
+                                      'p': 8,
+                                      'r': 1,
+                                      'salt': '...'},
+                        'mac': '...'},
+             'id': '...',
+             'version': 3}
 
             >>> with open('my-keyfile', 'w') as f: # doctest: +SKIP
             ...    f.write(json.dumps(encrypted))

--- a/eth_account/messages.py
+++ b/eth_account/messages.py
@@ -181,19 +181,20 @@ def encode_defunct(
     .. code-block:: python
 
         >>> from eth_account.messages import encode_defunct
+        >>> from eth_utils.curried import to_hex
 
         >>> message_text = "I♥SF"
         >>> encode_defunct(text=message_text)
         SignableMessage(version=b'E', header=b'thereum Signed Message:\n6', body=b'I\xe2\x99\xa5SF')
 
-        # these four also produce the same hash:
-        >>> encode_defunct(w3.toBytes(text=message_text)) # doctest: +SKIP
+        These four also produce the same hash:
+        >>> encode_defunct(to_bytes(text=message_text))
         SignableMessage(version=b'E', header=b'thereum Signed Message:\n6', body=b'I\xe2\x99\xa5SF')
 
         >>> encode_defunct(bytes(message_text, encoding='utf-8'))
         SignableMessage(version=b'E', header=b'thereum Signed Message:\n6', body=b'I\xe2\x99\xa5SF')
 
-        >>> Web3.toHex(text=message_text) # doctest: +SKIP
+        >>> to_hex(text=message_text)
         '0x49e299a55346'
         >>> encode_defunct(hexstr='0x49e299a55346')
         SignableMessage(version=b'E', header=b'thereum Signed Message:\n6', body=b'I\xe2\x99\xa5SF')


### PR DESCRIPTION
This is a follow up for comments to PR #49, closes #81.

## What was wrong?
Some doctests from `account.Account.encrypt()`, `account.Account.decrypt()` and `messages.encode_defunct()` were disabled (`+SKIP`) because they were failing.

Issue #81 

## How was it fixed?

- `account.Account.encrypt()` is now providing full deterministic input, including the input password
- `account.Account.decrypt()`
  - leverages [doctest ELLIPSIS](https://docs.python.org/3/library/doctest.html#doctest.ELLIPSIS) for non deterministic output
  - uses `pprint()` for clean indentation matching and deterministic dictionary key ordering
- `messages.encode_defunct()` uses `to_hex()` & `to_bytes()` from `eth_utils` rather than `web3`

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/24973/72670151-7a254b00-3a3a-11ea-94f7-efb1571fe1f4.png)
