### PR TITLE
Allow encoding of structured data containing bytes32

### DIFF
--- a/eth_account/messages.py
+++ b/eth_account/messages.py
@@ -1,7 +1,6 @@
 from collections.abc import (
     Mapping,
 )
-import json
 from typing import (
     NamedTuple,
     Union,
@@ -27,6 +26,9 @@ from eth_account._utils.structured_data.hashing import (
     hash_domain,
     hash_message as hash_eip712_message,
     load_and_validate_structured_message,
+)
+from eth_account._utils.structured_data.validation import (
+    validate_structured_data,
 )
 from eth_account._utils.validation import (
     is_valid_address,
@@ -143,10 +145,11 @@ def encode_structured_data(
     .. _EIP-712: https://eips.ethereum.org/EIPS/eip-712
     """
     if isinstance(primitive, Mapping):
-        message_string = json.dumps(primitive)
+        validate_structured_data(primitive)
+        structured_data = primitive
     else:
         message_string = to_text(primitive, hexstr=hexstr, text=text)
-    structured_data = load_and_validate_structured_message(message_string)
+        structured_data = load_and_validate_structured_message(message_string)
     return SignableMessage(
         HexBytes(b'\x01'),
         hash_domain(structured_data),

--- a/newsfragments/91.bugfix.rst
+++ b/newsfragments/91.bugfix.rst
@@ -1,0 +1,1 @@
+Allow encoding of structured data containing ``bytes``

--- a/tests/core/test_structured_data_signing.py
+++ b/tests/core/test_structured_data_signing.py
@@ -150,6 +150,16 @@ def test_hashed_structured_data(message_encodings):
     assert hashed_structured_msg.hex() == expected_hash_value_hex
 
 
+def test_hashed_structured_data_with_bytes32(structured_valid_data_json_string):
+    structured_data = json.loads(structured_valid_data_json_string)
+    structured_data['types']['Mail'][2]['type'] = "bytes32"
+    structured_data['message']['contents'] = keccak(b'')
+    structured_msg = encode_structured_data(structured_data)
+    hashed_structured_msg = _hash_eip191_message(structured_msg)
+    expected_hash_value_hex = "f7f87cf61cfd0094dbca5cbdc97154501f174f5b7ca53be23e1f3ea8005be468"
+    assert hashed_structured_msg.hex() == expected_hash_value_hex
+
+
 def test_signature_verification(message_encodings):
     account = Account.create()
     structured_msg = encode_structured_data(**message_encodings)

--- a/tests/core/test_structured_data_signing.py
+++ b/tests/core/test_structured_data_signing.py
@@ -150,13 +150,29 @@ def test_hashed_structured_data(message_encodings):
     assert hashed_structured_msg.hex() == expected_hash_value_hex
 
 
-def test_hashed_structured_data_with_bytes32(structured_valid_data_json_string):
+def test_hashed_structured_data_with_bytes(structured_valid_data_json_string):
     structured_data = json.loads(structured_valid_data_json_string)
-    structured_data['types']['Mail'][2]['type'] = "bytes32"
+
+    # change 'contents' field to type ``bytes`` and set bytes value
+    structured_data['types']['Mail'][3]['type'] = "bytes"
     structured_data['message']['contents'] = keccak(b'')
+
     structured_msg = encode_structured_data(structured_data)
     hashed_structured_msg = _hash_eip191_message(structured_msg)
-    expected_hash_value_hex = "f7f87cf61cfd0094dbca5cbdc97154501f174f5b7ca53be23e1f3ea8005be468"
+    expected_hash_value_hex = "a06e87f57db20fed78428850bfe02a67d4c6c0f9bcb582b860299b21f591b1c6"
+    assert hashed_structured_msg.hex() == expected_hash_value_hex
+
+
+def test_hashed_structured_data_with_bytes32(structured_valid_data_json_string):
+    structured_data = json.loads(structured_valid_data_json_string)
+
+    # change 'contents' field to type ``bytes32`` and set bytes value
+    structured_data['types']['Mail'][3]['type'] = "bytes32"
+    structured_data['message']['contents'] = keccak(b'')
+
+    structured_msg = encode_structured_data(structured_data)
+    hashed_structured_msg = _hash_eip191_message(structured_msg)
+    expected_hash_value_hex = "ff79c92bdd076a8ec12b146f82a278b30f4da5d402382e215abda4c3c186257e"
     assert hashed_structured_msg.hex() == expected_hash_value_hex
 
 


### PR DESCRIPTION
## What was wrong?
The json serialization in eth_account/messages.py:143 did not allow for bytes data to be used in a struct to be signed.

Issue #90 

## How was it fixed?
If the struct is a Mapping then we can skip the `json.dumps` -> `json.loads` pattern.

#### Cute Animal Picture

![axolotl](https://cdn.prod.www.spiegel.de/images/62829e6f-0001-0004-0000-000000156454_w1005_r1.33_fpx39.95_fpy50.jpg)
