### PR TITLE
Add package_data to setup.py for hdaccount wordlists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,24 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-integration
+  py36-wheel-cli:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-wheel-cli
+  py37-wheel-cli:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-wheel-cli
+  py38-wheel-cli:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-wheel-cli
 workflows:
   version: 2
   test:
@@ -136,3 +154,6 @@ workflows:
       - py36-integration
       - py37-integration
       - py38-integration
+      - py36-wheel-cli
+      - py37-wheel-cli
+      - py38-wheel-cli

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,7 +5,7 @@ include requirements-docs.txt
 global-include *.pyi
 
 # For mnemonics
-recursive-include eth_account/hdaccount/wordlist/*
+recursive-include eth_account hdaccount wordlist *.txt
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,7 +5,7 @@ include requirements-docs.txt
 global-include *.pyi
 
 # For mnemonics
-recursive-include eth_account hdaccount wordlist *.txt
+recursive-include eth_account/hdaccount/wordlist/*txt
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,7 +5,7 @@ include requirements-docs.txt
 global-include *.pyi
 
 # For mnemonics
-recursive-include eth_account/hdaccount/wordlist/*txt
+recursive-include eth_account/hdaccount/wordlist *txt
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,8 +4,8 @@ include requirements-docs.txt
 
 global-include *.pyi
 
-# For mnemonics 
-recursive-include hdaccount/wordlist/
+# For mnemonics
+recursive-include eth_account/hdaccount/wordlist/*
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,7 +82,8 @@ exclude_patterns = [
     '_build',
     'modules.rst',
     'eth_account.internal.rst',
-    'eth_account.hdaccount*',
+    'eth_account.hdaccount.rst',
+    'tests*',
 ]
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,7 +83,6 @@ exclude_patterns = [
     'modules.rst',
     'eth_account.internal.rst',
     'eth_account.hdaccount.rst',
-    'tests*',
 ]
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/setup.py
+++ b/setup.py
@@ -56,17 +56,6 @@ setup(
     url='https://github.com/ethereum/eth-account',
     include_package_data=True,
     package_data={"eth_account": ["hdaccount/wordlist/*.txt"]},
-    data_files=[('eth_account', [
-        'eth_account/hdaccount/wordlist/chinese_simplified.txt',
-        'eth_account/hdaccount/wordlist/chinese_traditional.txt',
-        'eth_account/hdaccount/wordlist/czech.txt',
-        'eth_account/hdaccount/wordlist/english.txt',
-        'eth_account/hdaccount/wordlist/french.txt',
-        'eth_account/hdaccount/wordlist/italian.txt',
-        'eth_account/hdaccount/wordlist/japanese.txt',
-        'eth_account/hdaccount/wordlist/korean.txt',
-        'eth_account/hdaccount/wordlist/spanish.txt',
-    ])],
     install_requires=[
         "bitarray>=1.2.1,<1.3.0",
         "eth-abi>=2.0.0b7,<3",

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,17 @@ setup(
     url='https://github.com/ethereum/eth-account',
     include_package_data=True,
     package_data={"eth_account": ["hdaccount/wordlist/*.txt"]},
+    data_files=[('eth_account', [
+        'eth_account/hdaccount/wordlist/chinese_simplified.txt',
+        'eth_account/hdaccount/wordlist/chinese_traditional.txt',
+        'eth_account/hdaccount/wordlist/czech.txt',
+        'eth_account/hdaccount/wordlist/english.txt',
+        'eth_account/hdaccount/wordlist/french.txt',
+        'eth_account/hdaccount/wordlist/italian.txt',
+        'eth_account/hdaccount/wordlist/japanese.txt',
+        'eth_account/hdaccount/wordlist/korean.txt',
+        'eth_account/hdaccount/wordlist/spanish.txt',
+    ])],
     install_requires=[
         "bitarray>=1.2.1,<1.3.0",
         "eth-abi>=2.0.0b7,<3",

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
     author_email='snakecharmers@ethereum.org',
     url='https://github.com/ethereum/eth-account',
     include_package_data=True,
+    package_data={"eth_account": ["hdaccount/wordlist/*.txt"]},
     install_requires=[
         "bitarray>=1.2.1,<1.3.0",
         "eth-abi>=2.0.0b7,<3",

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist=
     py{36,37,38}-integration
     lint
     docs
+    py{36,37,38}-wheel-cli
 
 [isort]
 combine_as_imports=True
@@ -45,7 +46,7 @@ commands=
     isort --recursive --check-only --diff {toxinidir}/eth_account {toxinidir}/tests
     pydocstyle {toxinidir}/eth_account {toxinidir}/tests
 
-[common-gzip-dist-cli]
+[common-wheel-cli]
 deps=wheel
 whitelist_externals=
     /bin/rm
@@ -53,22 +54,23 @@ whitelist_externals=
 commands=
     /bin/rm -rf build dist
     python setup.py sdist bdist_wheel
-    /bin/bash -c 'tar -tf "$(ls dist/eth-account-*.tar.gz)" eth-account-*/eth_account/hdaccount/wordlist/*txt'
+    /bin/bash -c 'pip install --upgrade "$(ls dist/eth_account-*-py3-none-any.whl)" --progress-bar off'
+    python -c "from eth_account import Account"
 
-[testenv:py36-gzip-dist-cli]
-deps={[common-gzip-dist-cli]deps}
-whitelist_externals={[common-gzip-dist-cli]whitelist_externals}
-commands={[common-gzip-dist-cli]commands}
+[testenv:py36-wheel-cli]
+deps={[common-wheel-cli]deps}
+whitelist_externals={[common-wheel-cli]whitelist_externals}
+commands={[common-wheel-cli]commands}
 skip_install=true
 
-[testenv:py37-gzip-dist-cli]
-deps={[common-gzip-dist-cli]deps}
-whitelist_externals={[common-gzip-dist-cli]whitelist_externals}
-commands={[common-gzip-dist-cli]commands}
+[testenv:py37-wheel-cli]
+deps={[common-wheel-cli]deps}
+whitelist_externals={[common-wheel-cli]whitelist_externals}
+commands={[common-wheel-cli]commands}
 skip_install=true
 
-[testenv:py38-gzip-dist-cli]
-deps={[common-gzip-dist-cli]deps}
-whitelist_externals={[common-gzip-dist-cli]whitelist_externals}
-commands={[common-gzip-dist-cli]commands}
+[testenv:py38-wheel-cli]
+deps={[common-wheel-cli]deps}
+whitelist_externals={[common-wheel-cli]whitelist_externals}
+commands={[common-wheel-cli]commands}
 skip_install=true

--- a/tox.ini
+++ b/tox.ini
@@ -44,3 +44,31 @@ commands=
     flake8 {toxinidir}/eth_account {toxinidir}/tests
     isort --recursive --check-only --diff {toxinidir}/eth_account {toxinidir}/tests
     pydocstyle {toxinidir}/eth_account {toxinidir}/tests
+
+[common-gzip-dist-cli]
+deps=wheel
+whitelist_externals=
+    /bin/rm
+    /bin/bash
+commands=
+    /bin/rm -rf build dist
+    python setup.py sdist bdist_wheel
+    /bin/bash -c 'tar -tf "$(ls dist/eth-account-*.tar.gz)" eth-account-*/eth_account/hdaccount/wordlist/*txt'
+
+[testenv:py36-gzip-dist-cli]
+deps={[common-gzip-dist-cli]deps}
+whitelist_externals={[common-gzip-dist-cli]whitelist_externals}
+commands={[common-gzip-dist-cli]commands}
+skip_install=true
+
+[testenv:py37-gzip-dist-cli]
+deps={[common-gzip-dist-cli]deps}
+whitelist_externals={[common-gzip-dist-cli]whitelist_externals}
+commands={[common-gzip-dist-cli]commands}
+skip_install=true
+
+[testenv:py38-gzip-dist-cli]
+deps={[common-gzip-dist-cli]deps}
+whitelist_externals={[common-gzip-dist-cli]whitelist_externals}
+commands={[common-gzip-dist-cli]commands}
+skip_install=true

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,6 @@ exclude= venv*,.tox,docs,build
 ignore=
 
 [testenv]
-usedevelop=True
 commands=
     core: pytest {posargs:tests/core}
     integration: pytest {posargs:tests/integration}


### PR DESCRIPTION
## What was wrong?
Web3py couldn't use the new HD Account methods because the wordlists (raw txt files) weren't getting included in the release.

Fixes #102 


## How was it fixed?
Added a line to setup.py to include them, and tested in web3 using a local install of eth-account.

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/80012492-a2ce3e00-848a-11ea-9911-9bbc0ebaa490.png)

