### PR TITLE
WIP: Require checksum addresses in typed/structured messages

### DIFF
--- a/tests/fixtures/valid_message.json
+++ b/tests/fixtures/valid_message.json
@@ -36,11 +36,11 @@
 		"cc": [
       {
         "name": "Alice",
-        "wallet": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "wallet": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
       },
       {
         "name": "Dot",
-        "wallet": "0xdddddddddddddddddddddddddddddddddddddddd"
+        "wallet": "0xDDdDddDdDdddDDddDDddDDDDdDdDDdDDdDDDDDDd"
       }
     ],
 		"contents": "Hello, Bob!"


### PR DESCRIPTION
## What was wrong?

Checksummed addresses weren't enforced. Seems like something worth doing.

## How was it fixed?

I tried adding a checksum requirement. Then when I changed the addresses to be checksummed... the hash changed! :scream: (whether the type was left as "address" or "uint160")

I don't have time to dig in at this moment, so this is just a starting point for someone else or me to pick up sometime later.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/67/e1/50/67e150b08f5f240ab96ffe54f0d9bb67.jpg)
