### PR TITLE
Add newsfragment for #99

### DIFF
--- a/newsfragments/99.bugfix.rst
+++ b/newsfragments/99.bugfix.rst
@@ -1,0 +1,1 @@
+Makes sure that the raw txt files needed for Mnemonics get packaged with the release.


### PR DESCRIPTION
## What was wrong?
Didn't realize towncrier was set up for eth-account. 

## How was it fixed?
Added a newsfragment!

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/80618917-3e1e6080-8a01-11ea-8926-ff9622738a88.png)

