### PR TITLE
Allow rlp up to v2-alpha1

### DIFF
--- a/eth_account/_utils/transactions.py
+++ b/eth_account/_utils/transactions.py
@@ -1,4 +1,7 @@
 import itertools
+from typing import (
+    Dict,
+)
 
 from cytoolz import (
     curry,
@@ -137,6 +140,7 @@ def assert_valid_fields(transaction_dict):
         raise TypeError("Transaction must not include unrecognized fields: %r" % superfluous_keys)
 
     # check for valid types in each field
+    valid_fields: Dict[str, bool]
     valid_fields = apply_formatters_to_dict(TRANSACTION_VALID_VALUES, transaction_dict)
     if not all(valid_fields.values()):
         invalid = {key: transaction_dict[key] for key, valid in valid_fields.items() if not valid}

--- a/eth_account/messages.py
+++ b/eth_account/messages.py
@@ -100,10 +100,13 @@ def encode_intended_validator(
             f"Cannot encode message with 'Validator Address': {validator_address}. "
             "It must be a checksum address, or an address converted to bytes."
         )
+    # The validator_address is a str or Address (which is a subtype of bytes). Both of
+    #   these are AnyStr, which includes str and bytes. Not sure why mypy complains here...
+    canonical_address = to_canonical_address(validator_address)  # type: ignore
     message_bytes = to_bytes(primitive, hexstr=hexstr, text=text)
     return SignableMessage(
         HexBytes(b'\x00'),  # version 0, as defined in EIP-191
-        to_canonical_address(validator_address),
+        canonical_address,
         message_bytes,
     )
 

--- a/newsfragments/104.performance.rst
+++ b/newsfragments/104.performance.rst
@@ -1,0 +1,1 @@
+RLP encoding/decoding speedup by permitting rlp v2alpha1 with rust implementation.

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         "eth-rlp>=0.1.2,<1",
         "eth-utils>=1.3.0,<2",
         "hexbytes>=0.1.0,<1",
-        "rlp>=1.0.0,<2"
+        "rlp>=1.0.0,<=2.0.0.alpha-1"
     ],
     python_requires='>=3.6, <4',
     extras_require=extras_require,


### PR DESCRIPTION
Upgrade rlp to allow downstream libraries to use the latest v2 alpha. See https://github.com/ethereum/trinity/pull/2004

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/18/2d/2f/182d2f7098984d88e31e2cd2b53e5729.jpg)
