### PR TITLE
Relax upper bound of dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,10 +61,10 @@ setup(
         "eth-abi>=2.0.0b7,<3",
         "eth-keyfile>=0.5.0,<0.6.0",
         "eth-keys>=0.2.1,<0.4.0,!=0.3.2",
-        "eth-rlp>=0.1.2,<1",
+        "eth-rlp>=0.1.2,<2",
         "eth-utils>=1.3.0,<2",
         "hexbytes>=0.1.0,<1",
-        "rlp>=1.0.0,<=2.0.0.alpha-1"
+        "rlp>=1.0.0,<3"
     ],
     python_requires='>=3.6, <4',
     extras_require=extras_require,


### PR DESCRIPTION
### What was wrong?

The current RLP dependency has a hard bound on `2.0.0a1`. Trinity, Py-EVM and friends need to migrate to `2.0.0a2` so we need to update the dependency. 

### How was it fixed?

Changed it to `"rlp>=1,<3"` which is  inline with what [`eth-enr` does](https://github.com/ethereum/eth-enr/blob/master/setup.py#L64) and causes less cascading releases whenever we cut a new alpha release of RLP.

#### Cute Animal Picture

![Cute animal picture](https://imgs.abduzeedo.com/files/articles/baby-animals/Baby-Animals-001.jpg)
