### PR TITLE
Upgrade to the latest template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ develop-eggs
 .installed.cfg
 lib
 lib64
+pip-wheel-metadata
 venv*
 
 # Installer logs
@@ -55,13 +56,10 @@ chains
 
 # tox/pytest cache
 .cache
+.pytest_cache
 
 # Test output logs
 logs
-### JetBrains template
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
-# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
-.idea
 
 # VIM temp files
 *.sw[op]
@@ -69,23 +67,32 @@ logs
 # mypy
 .mypy_cache
 
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# For a more precise, explicit template, see:
+# https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+## General
+.idea/*
+.idea_modules/*
+
 ## File-based project format:
 *.iws
 
+## IntelliJ
+out/
+
 ## Plugin-specific files:
 
-# IntelliJ
-/out/
-
-# mpeltonen/sbt-idea plugin
+### mpeltonen/sbt-idea plugin
 .idea_modules/
 
-# JIRA plugin
+### JIRA plugin
 atlassian-ide-plugin.xml
 
-# Crashlytics plugin (for Android Studio and IntelliJ)
+### Crashlytics plugin (for Android Studio and IntelliJ)
 com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
 
+# END JetBrains section

--- a/.project-template/fill_template_vars.sh
+++ b/.project-template/fill_template_vars.sh
@@ -47,3 +47,4 @@ _replace "s/<SHORT_DESCRIPTION>/$SHORT_DESCRIPTION/g"
 
 mkdir -p "$PROJECT_ROOT/$MODULE_NAME"
 touch "$PROJECT_ROOT/$MODULE_NAME/__init__.py"
+touch "$PROJECT_ROOT/$MODULE_NAME/py.typed"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Sign Ethereum transactions and messages with local private keys
 
-Read more in the [documentation on ReadTheDocs](https://<RTD_NAME>.readthedocs.io/). [View the change log](https://<RTD_NAME>.readthedocs.io/en/latest/release_notes.html).
+Read more in the [documentation on ReadTheDocs](https://eth-account.readthedocs.io/). [View the change log](https://eth-account.readthedocs.io/en/latest/release_notes.html).
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Sign Ethereum transactions and messages with local private keys
 
-Read more in the [documentation on ReadTheDocs](http://eth-account.readthedocs.io/). [View the change log](http://eth-account.readthedocs.io/en/latest/releases.html)
+Read more in the [documentation on ReadTheDocs](https://<RTD_NAME>.readthedocs.io/). [View the change log](https://<RTD_NAME>.readthedocs.io/en/latest/release_notes.html).
 
 ## Quickstart
 

--- a/eth_account/_utils/signing.py
+++ b/eth_account/_utils/signing.py
@@ -81,7 +81,8 @@ def hash_of_signed_transaction(txn_obj):
 
 def extract_chain_id(raw_v):
     """
-    Extracts chain ID, according to EIP-155
+    Extracts chain ID, according to EIP-155.
+
     @return (chain_id, v)
     """
     above_id_offset = raw_v - CHAIN_ID_OFFSET

--- a/eth_account/_utils/structured_data/hashing.py
+++ b/eth_account/_utils/structured_data/hashing.py
@@ -28,7 +28,7 @@ from .validation import (
 
 def get_dependencies(primary_type, types):
     """
-    Perform DFS to get all the dependencies of the primary_type
+    Perform DFS to get all the dependencies of the primary_type.
     """
     deps = set()
     struct_names_yet_to_be_expanded = [primary_type]
@@ -57,6 +57,8 @@ def get_dependencies(primary_type, types):
 
 def field_identifier(field):
     """
+    Convert a field dict into a typed-name string.
+
     Given a ``field`` of the format {'name': NAME, 'type': TYPE},
     this function converts it to ``TYPE NAME``
     """
@@ -72,6 +74,8 @@ def encode_struct(struct_name, struct_field_types):
 
 def encode_type(primary_type, types):
     """
+    Serialize types into an encoded string.
+
     The type of a struct is encoded as name ‖ "(" ‖ member₁ ‖ "," ‖ member₂ ‖ "," ‖ … ‖ memberₙ ")"
     where each member is written as type ‖ " " ‖ name.
     """
@@ -101,7 +105,7 @@ def is_array_type(type):
 @to_tuple
 def get_depths_and_dimensions(data, depth):
     """
-    Yields 2-length tuples of depth and dimension of each element at that depth
+    Yields 2-length tuples of depth and dimension of each element at that depth.
     """
     if not isinstance(data, (list, tuple)):
         # Not checking for Iterable instance, because even Dictionaries and strings
@@ -117,8 +121,8 @@ def get_depths_and_dimensions(data, depth):
 
 def get_array_dimensions(data):
     """
-    Given an array type data item, check that it is an array and
-    return the dimensions as a tuple.
+    Given an array type data item, check that it is an array and return the dimensions as a tuple.
+
     Ex: get_array_dimensions([[1, 2, 3], [4, 5, 6]]) returns (2, 3)
     """
     depths_and_dimensions = get_depths_and_dimensions(data, 0)

--- a/eth_account/_utils/typed_transactions.py
+++ b/eth_account/_utils/typed_transactions.py
@@ -161,7 +161,9 @@ class TypedTransaction():
 
     def hash(self) -> bytes:
         """
-        Hashes this TypedTransaction to prepare it for signing. As per the EIP-2718 specifications,
+        Hashes this TypedTransaction to prepare it for signing.
+
+        As per the EIP-2718 specifications,
         the hashing format is dictated by the transaction type itself, and so we delegate the call.
         Note that the return type will be bytes.
         """
@@ -169,7 +171,9 @@ class TypedTransaction():
 
     def encode(self) -> bytes:
         """
-        Encodes this TypedTransaction and returns it as bytes. The transaction format follows
+        Encodes this TypedTransaction and returns it as bytes.
+
+        The transaction format follows
         EIP-2718's typed transaction format (TransactionType || TransactionPayload).
         Note that we delegate to a transaction type's payload() method as the EIP-2718 does not
         prescribe a TransactionPayload format, leaving types free to implement their own encoding.
@@ -320,7 +324,9 @@ class AccessListTransaction(_TypedTransactionImplementation):
 
     def payload(self) -> bytes:
         """
-        Returns this transaction's payload as bytes. Here, the TransactionPayload = rlp([chainId,
+        Returns this transaction's payload as bytes.
+
+        Here, the TransactionPayload = rlp([chainId,
         nonce, gasPrice, gasLimit, to, value, data, accessList, signatureYParity, signatureR,
         signatureS])
         """
@@ -475,7 +481,9 @@ class DynamicFeeTransaction(_TypedTransactionImplementation):
 
     def payload(self) -> bytes:
         """
-        Returns this transaction's payload as bytes. Here, the TransactionPayload = rlp([chainId,
+        Returns this transaction's payload as bytes.
+
+        Here, the TransactionPayload = rlp([chainId,
         nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, accessList,
         signatureYParity, signatureR, signatureS])
         """

--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -114,8 +114,9 @@ class Account(object):
     @staticmethod
     def decrypt(keyfile_json, password):
         """
-        Decrypts a private key that was encrypted using an Ethereum client or
-        :meth:`~Account.encrypt`.
+        Decrypts a private key.
+
+        The key may have been encrypted using an Ethereum client or :meth:`~Account.encrypt`.
 
         :param keyfile_json: The encrypted key
         :type keyfile_json: dict or str
@@ -255,6 +256,7 @@ class Account(object):
                       passphrase: str = "",
                       account_path: str = ETHEREUM_DEFAULT_PATH):
         """
+        Generate an account from a mnemonic.
 
         .. CAUTION:: This feature is experimental, unaudited, and likely to change soon
 
@@ -297,6 +299,7 @@ class Account(object):
                              language: str = "english",
                              account_path: str = ETHEREUM_DEFAULT_PATH):
         r"""
+        Create a new private key and related mnemonic.
 
         .. CAUTION:: This feature is experimental, unaudited, and likely to change soon
 
@@ -558,16 +561,16 @@ class Account(object):
     @combomethod
     def signHash(self, message_hash, private_key):
         """
+        Sign the provided hash.
+
         .. WARNING:: *Never* sign a hash that you didn't generate,
             it can be an arbitrary transaction. For example, it might
             send all of your account's ether to an attacker.
             Instead, prefer :meth:`~eth_account.account.Account.sign_message`,
             which cannot accidentally sign a transaction.
 
-        Sign the provided hash.
-
         .. CAUTION:: Deprecated for :meth:`~eth_account.account.Account.sign_message`.
-            This method will be removed in v0.5
+            This method will be removed in v0.6
 
         :param message_hash: the 32-byte message hash to be signed
         :type message_hash: hex str, bytes or int
@@ -615,11 +618,12 @@ class Account(object):
     @combomethod
     def sign_transaction(self, transaction_dict, private_key):
         """
-        Sign a transaction using a local private key. Produces signature details
-        and the hex-encoded transaction suitable for broadcast using
+        Sign a transaction using a local private key.
+
+        It produces signature details and the hex-encoded transaction suitable for broadcast using
         :meth:`w3.eth.sendRawTransaction() <web3.eth.Eth.sendRawTransaction>`.
 
-        Create the transaction dict for a contract method with
+        To create the transaction dict that calls a contract, use contract object:
         `my_contract.functions.my_function().buildTransaction()
         <http://web3py.readthedocs.io/en/latest/contracts.html#methods>`_
 
@@ -749,8 +753,9 @@ class Account(object):
     @combomethod
     def _parsePrivateKey(self, key):
         """
-        Generate a :class:`eth_keys.datatypes.PrivateKey` from the provided key. If the
-        key is already of type :class:`eth_keys.datatypes.PrivateKey`, return the key.
+        Generate a :class:`eth_keys.datatypes.PrivateKey` from the provided key.
+
+        If the key is already of type :class:`eth_keys.datatypes.PrivateKey`, return the key.
 
         :param key: the private key from which a :class:`eth_keys.datatypes.PrivateKey`
                     will be generated

--- a/eth_account/hdaccount/_utils.py
+++ b/eth_account/hdaccount/_utils.py
@@ -36,7 +36,7 @@ def sha256(data: bytes) -> bytes:
 
 def hmac_sha512(chain_code: bytes, data: bytes) -> bytes:
     """
-    As specified by RFC4231 - https://tools.ietf.org/html/rfc4231
+    As specified by RFC4231 - https://tools.ietf.org/html/rfc4231 .
     """
     return hmac.new(chain_code, data, hashlib.sha512).digest()
 
@@ -52,7 +52,7 @@ def pbkdf2_hmac_sha512(passcode: str, salt: str) -> bytes:
 
 def ec_point(pkey: bytes) -> bytes:
     """
-    Compute `point(p)`, where `point` is ecdsa point multiplication
+    Compute `point(p)`, where `point` is ecdsa point multiplication.
 
     Note: Result is ecdsa public key serialized to compressed form
     """

--- a/eth_account/hdaccount/deterministic.py
+++ b/eth_account/hdaccount/deterministic.py
@@ -1,5 +1,5 @@
 """
-Heirarchical Deterministic Wallet generator (HDWallet)
+Generate Heirarchical Deterministic Wallets (HDWallet).
 
 Partially implements the BIP-0032, BIP-0043, and BIP-0044 specifications:
 BIP-0032: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
@@ -62,7 +62,7 @@ HARD_NODE_SUFFIXES = {"'", "H"}
 
 class Node(int):
     """
-    Base node class
+    A base node class.
     """
 
     TAG = ""  # No tag
@@ -115,7 +115,7 @@ class Node(int):
 
 class SoftNode(Node):
     """
-    Soft node (unhardened), where value = index
+    Soft node (unhardened), where value = index .
     """
     TAG = ""  # No tag
     OFFSET = 0x0  # No offset
@@ -123,7 +123,7 @@ class SoftNode(Node):
 
 class HardNode(Node):
     """
-    Hard node, where value = index + BIP32_HARDENED_CONSTANT
+    Hard node, where value = index + BIP32_HARDENED_CONSTANT .
     """
     TAG = "H"  # "H" (or "'") means hard node (but use "H" for clarity)
     OFFSET = 0x80000000  # 2**31, BIP32 "Hardening constant"
@@ -135,6 +135,8 @@ def derive_child_key(
     node: Node,
 ) -> Tuple[bytes, bytes]:
     """
+    Compute a derivitive key from the parent key.
+
     From BIP32:
 
     The function CKDpriv((k_par, c_par), i) → (k_i, c_i) computes a child extended
@@ -185,7 +187,9 @@ def derive_child_key(
 class HDPath:
     def __init__(self, path: str):
         """
-        Constructor for this class. Initializes an hd account generator using the
+        Create a new Hierarchical Deterministic path by decoding the given path.
+
+        Initializes an hd account generator using the
         given path string (from BIP-0032). The path is decoded into nodes of the
         derivation key tree, which define a pathway from a given master seed to
         the child key that is used for a given purpose. Please also reference BIP-
@@ -222,14 +226,14 @@ class HDPath:
 
     def encode(self) -> str:
         """
-        Encodes this class to a string (reversing the decoding in the constructor)
+        Encodes this class to a string (reversing the decoding in the constructor).
         """
         encoded_path = ('m',) + tuple(node.encode() for node in self._path)
         return '/'.join(encoded_path)
 
     def derive(self, seed: bytes) -> bytes:
         """
-        Perform the BIP32 Heirarchical Derivation recursive loop with the given Path
+        Perform the BIP32 Heirarchical Derivation recursive loop with the given Path.
 
         Note that the key and chain_code are initialized with the master seed, and that
         the key that is returned is the child key at the end of derivation process (and

--- a/eth_account/messages.py
+++ b/eth_account/messages.py
@@ -97,7 +97,7 @@ def encode_intended_validator(
     """
     if not is_valid_address(validator_address):
         raise ValidationError(
-            f"Cannot encode message with 'Validator Address': {validator_address}. "
+            f"Cannot encode message with 'Validator Address': {validator_address!r}. "
             "It must be a checksum address, or an address converted to bytes."
         )
     # The validator_address is a str or Address (which is a subtype of bytes). Both of

--- a/eth_account/messages.py
+++ b/eth_account/messages.py
@@ -38,9 +38,12 @@ text_to_bytes = text_if_str(to_bytes)
 # watch for updates to signature format
 class SignableMessage(NamedTuple):
     """
-    These are the components of an EIP-191_ signable message. Other message formats
+    A message compatible with EIP-191_ that is ready to be signed.
+
+    The properties are components of an EIP-191_ signable message. Other message formats
     can be encoded into this format for easy signing. This data structure doesn't need to
-    know about the original message format.
+    know about the original message format. For example, you can think of
+    EIP-712 as compiling down to an EIP-191 message.
 
     In typical usage, you should never need to create these by hand. Instead, use
     one of the available encode_* methods in this module, like:
@@ -76,8 +79,7 @@ def encode_intended_validator(
         hexstr: str = None,
         text: str = None) -> SignableMessage:
     """
-    Encode a message using the "intended validator" approach (ie~ version 0)
-    defined in EIP-191_.
+    Encode a message using the "intended validator" approach (ie~ version 0) defined in EIP-191_.
 
     Supply the message as exactly one of these three arguments:
     bytes as a primitive, a hex string, or a unicode string.
@@ -117,8 +119,9 @@ def encode_structured_data(
         hexstr: str = None,
         text: str = None) -> SignableMessage:
     """
-    Encode a message using the "structured data" approach (ie~ version 1)
-    defined in EIP-712_.
+    Encode an EIP-712_ message.
+
+    EIP-712 is the "structured data" approach (ie~ version 1 of an EIP-191 message).
 
     Supply the message as exactly one of the three arguments:
 

--- a/eth_account/signers/base.py
+++ b/eth_account/signers/base.py
@@ -10,8 +10,7 @@ from eth_account.messages import (
 
 class BaseAccount(ABC):
     """
-    Abstract class that defines a collection of convenience methods
-    to sign transactions and message hashes.
+    Specify convenience methods to sign transactions and message hashes.
     """
 
     @property
@@ -31,7 +30,10 @@ class BaseAccount(ABC):
     @abstractmethod
     def sign_message(self, signable_message: SignableMessage):
         """
-        Sign the EIP-191_ message, as in :meth:`~eth_account.account.Account.sign_message`
+        Sign the EIP-191_ message.
+
+        This uses the same structure
+        as in :meth:`~eth_account.account.Account.sign_message`
         but without specifying the private key.
 
         :param signable_message: The encoded message, ready for signing
@@ -43,11 +45,14 @@ class BaseAccount(ABC):
     @abstractmethod
     def signHash(self, message_hash):
         """
-        Sign the hash of a message, as in :meth:`~eth_account.account.Account.signHash`
+        Sign the hash of a message.
+
+        This uses the same structure
+        as in :meth:`~eth_account.account.Account.signHash`
         but without specifying the private key.
 
         .. CAUTION:: Deprecated for :meth:`~eth_account.signers.base.BaseAccount.sign_message`.
-            To be removed in v0.5
+            To be removed in v0.6
 
         :param bytes message_hash: 32 byte hash of the message to sign
         """
@@ -56,11 +61,14 @@ class BaseAccount(ABC):
     @abstractmethod
     def signTransaction(self, transaction_dict):
         """
-        Sign a transaction, as in :meth:`~eth_account.account.Account.sign_transaction`
+        Sign a transaction dict.
+
+        This uses the same structure as in
+        :meth:`~eth_account.account.Account.sign_transaction`
         but without specifying the private key.
 
         .. CAUTION:: Deprecated for :meth:`~eth_account.account.signers.local.sign_transaction`.
-            This method will be removed in v0.5
+            This method will be removed in v0.6
 
         :param dict transaction_dict: transaction with all fields specified
         """
@@ -69,7 +77,10 @@ class BaseAccount(ABC):
     @abstractmethod
     def sign_transaction(self, transaction_dict):
         """
-        Sign a transaction, as in :meth:`~eth_account.account.Account.sign_transaction`
+        Sign a transaction dict.
+
+        This uses the same structure as in
+        :meth:`~eth_account.account.Account.sign_transaction`
         but without specifying the private key.
 
         :param dict transaction_dict: transaction with all fields specified

--- a/eth_account/signers/local.py
+++ b/eth_account/signers/local.py
@@ -27,6 +27,8 @@ class LocalAccount(BaseAccount):
     """
     def __init__(self, key, account):
         """
+        Initialize a new account with the the given private key.
+
         :param eth_keys.PrivateKey key: to prefill in private key execution
         :param ~eth_account.account.Account account: the key-unaware management API
         """
@@ -64,7 +66,9 @@ class LocalAccount(BaseAccount):
 
     def encrypt(self, password, kdf=None, iterations=None):
         """
-        Generate a string with the encrypted key, as in
+        Generate a string with the encrypted key.
+
+        This uses the same structure as in
         :meth:`~eth_account.account.Account.encrypt`, but without a private key argument.
         """
         return self._publicapi.encrypt(self.key, password, kdf=kdf, iterations=iterations)
@@ -77,7 +81,9 @@ class LocalAccount(BaseAccount):
 
     def sign_message(self, signable_message):
         """
-        Generate a string with the encrypted key, as in
+        Generate a string with the encrypted key.
+
+        This uses the same structure as in
         :meth:`~eth_account.account.Account.sign_message`, but without a private key argument.
         """
         return self._publicapi.sign_message(signable_message, private_key=self.key)

--- a/newsfragments/121.internal.rst
+++ b/newsfragments/121.internal.rst
@@ -1,0 +1,1 @@
+Upgrade project template, of note: a new mypy & pydocstyle, and types being exported correctly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ package = "eth_account"
 filename = "docs/release_notes.rst"
 directory = "newsfragments"
 underlines = ["-", "~", "^"]
-title_format = "v{version} ({project_date})"
+title_format = "eth-account v{version} ({project_date})"
 issue_format = "`#{issue} <https://github.com/ethereum/eth-account/issues/{issue}>`__"
 
 [[tool.towncrier.type]]

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,10 @@ setup(
     author_email='snakecharmers@ethereum.org',
     url='https://github.com/ethereum/eth-account',
     include_package_data=True,
-    package_data={"eth_account": ["hdaccount/wordlist/*.txt"]},
+    package_data={"eth_account": [
+        "py.typed",
+        "hdaccount/wordlist/*.txt",
+    ]},
     install_requires=[
         "bitarray>=1.2.1,<1.3.0",
         "eth-abi>=2.0.0b7,<3",
@@ -73,7 +76,6 @@ setup(
     zip_safe=False,
     keywords='ethereum',
     packages=find_packages(exclude=["tests", "tests.*"]),
-    package_data={'<MODULE_NAME>': ['py.typed']},
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -8,19 +8,19 @@ from setuptools import (
 extras_require = {
     'test': [
         "hypothesis>=4.18.0,<5",
-        "pytest>=4.4.0,<5",
+        "pytest==5.4.1",
         "pytest-xdist",
-        "tox>=2.9.1,<3",
+        "tox==3.14.6",
     ],
     'lint': [
         "flake8==3.7.9",
         "isort>=4.2.15,<5",
-        "mypy==0.701",
-        "pydocstyle>=3.0.0,<4",
+        "mypy==0.770",
+        "pydocstyle>=5.0.0,<6",
     ],
     'doc': [
         "Sphinx>=1.6.5,<2",
-        "sphinx_rtd_theme>=0.1.9",
+        "sphinx_rtd_theme>=0.1.9,<1",
         "towncrier>=19.2.0, <20",
     ],
     'dev': [
@@ -73,11 +73,14 @@ setup(
     zip_safe=False,
     keywords='ethereum',
     packages=find_packages(exclude=["tests", "tests.*"]),
+    package_data={'<MODULE_NAME>': ['py.typed']},
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
+        'Operating System :: MacOS',
+        'Operating System :: POSIX',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ whitelist_externals=make
 basepython=python
 extras=lint
 commands=
-    mypy -p {toxinidir}/eth_account --config-file {toxinidir}/mypy.ini
+    mypy -p eth_account --config-file {toxinidir}/mypy.ini
     flake8 {toxinidir}/eth_account {toxinidir}/tests
     isort --recursive --check-only --diff {toxinidir}/eth_account {toxinidir}/tests
     pydocstyle {toxinidir}/eth_account {toxinidir}/tests


### PR DESCRIPTION
## What was wrong?

`typed-ast` was not building in a fresh install. An issue indicated that an old mypy version (in use by eth-account) was responsible.

## How was it fixed?

The template repo is using a more recent version of mypy and surely includes other upgrades and fixes. So I pulled in all the template changes.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2020/06/black-rain-frogs-2-5edf2a036a852__700.jpg)