### PR TITLE
Explicitly reexport Account

### DIFF
--- a/eth_account/__init__.py
+++ b/eth_account/__init__.py
@@ -1,3 +1,5 @@
-from eth_account.account import (  # noqa: F401
+from eth_account.account import (
     Account,
 )
+
+__all__ = ["Account"]


### PR DESCRIPTION
This allows users to
    from eth_account import Account
without getting an error with the mypy flag
https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-implicit-reexport

## What was wrong?

Got mypy complaining about implicit reexport when

```
from eth_account import Account
```

## How was it fixed?

Explicitly reexport Account

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://camo.githubusercontent.com/c4858a9c55d2f27a28cb84bd81d1d9603d9c4a2195f3e307ca7375d981d406b7/68747470733a2f2f7374617469632e626f72656470616e64612e636f6d2f626c6f672f77702d636f6e74656e742f757575706c6f6164732f637574652d626162792d616e696d616c732f637574652d626162792d616e696d616c732d322e6a7067)
