### PR TITLE
doc: replace dup method with missing method

### DIFF
--- a/eth_account/messages.py
+++ b/eth_account/messages.py
@@ -50,7 +50,7 @@ class SignableMessage(NamedTuple):
 
         - :meth:`encode_structured_data`
         - :meth:`encode_intended_validator`
-        - :meth:`encode_structured_data`
+        - :meth:`encode_defunct`
 
     .. _EIP-191: https://eips.ethereum.org/EIPS/eip-191
     """

--- a/newsfragments/127.doc.rst
+++ b/newsfragments/127.doc.rst
@@ -1,0 +1,1 @@
+Replace duplicate method with missing method


### PR DESCRIPTION
## What was wrong?

A factory-like method was listed twice in the `SignableMessage` documentation and one of the factory-like methods was missing  

## How was it fixed?

Replaced duplicated method with the missing one in the doc

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

🐕 
