### PR TITLE
fix: add missing f-str

### DIFF
--- a/eth_account/messages.py
+++ b/eth_account/messages.py
@@ -63,7 +63,7 @@ def _hash_eip191_message(signable_message: SignableMessage) -> Hash32:
     version = signable_message.version
     if len(version) != 1:
         raise ValidationError(
-            "The supplied message version is {version!r}. "
+            f"The supplied message version is {version!r}. "
             "The EIP-191 signable message standard only supports one-byte versions."
         )
 

--- a/newsfragments/128.bugfix.rst
+++ b/newsfragments/128.bugfix.rst
@@ -1,0 +1,1 @@
+Fix string interpolation in ``ValidationError`` message of _hash_eip_191_message


### PR DESCRIPTION
## What was wrong?

Issue # One of the validation error was missing an `f` in its string-interpolation 

## How was it fixed?

Prefixed str with `f`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

🐶 
