### PR TITLE
Drop Python 3.6 support, Add Python 3.9-3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,21 +79,15 @@ jobs:
   docs:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.8
         environment:
           TOXENV: docs
   lint:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.8
         environment:
           TOXENV: lint
-  py36-core:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-core
   py37-core:
     <<: *common
     docker:
@@ -106,12 +100,6 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-core
-  py36-integration:
-    <<: *integration
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-integration
   py37-integration:
     <<: *integration
     docker:
@@ -124,12 +112,6 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-integration
-  py36-wheel-cli:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-wheel-cli
   py37-wheel-cli:
     <<: *common
     docker:
@@ -148,12 +130,9 @@ workflows:
     jobs:
       - docs
       - lint
-      - py36-core
       - py37-core
       - py38-core
-      - py36-integration
       - py37-integration
       - py38-integration
-      - py36-wheel-cli
       - py37-wheel-cli
       - py38-wheel-cli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-core
+  py310-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-core
   py37-integration:
     <<: *integration
     docker:
@@ -124,6 +130,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-integration
+  py310-integration:
+    <<: *integration
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-integration
   py37-wheel-cli:
     <<: *common
     docker:
@@ -142,6 +154,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-wheel-cli
+  py310-wheel-cli:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-wheel-cli
 workflows:
   version: 2
   test:
@@ -151,9 +169,12 @@ workflows:
       - py37-core
       - py38-core
       - py39-core
+      - py310-core
       - py37-integration
       - py38-integration
       - py39-integration
+      - py310-integration
       - py37-wheel-cli
       - py38-wheel-cli
       - py39-wheel-cli
+      - py310-wheel-cli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-core
+  py39-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-core
   py37-integration:
     <<: *integration
     docker:
@@ -112,6 +118,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-integration
+  py39-integration:
+    <<: *integration
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-integration
   py37-wheel-cli:
     <<: *common
     docker:
@@ -124,6 +136,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-wheel-cli
+  py39-wheel-cli:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-wheel-cli
 workflows:
   version: 2
   test:
@@ -132,7 +150,10 @@ workflows:
       - lint
       - py37-core
       - py38-core
+      - py39-core
       - py37-integration
       - py38-integration
+      - py39-integration
       - py37-wheel-cli
       - py38-wheel-cli
+      - py39-wheel-cli

--- a/newsfragments/139.feature.rst
+++ b/newsfragments/139.feature.rst
@@ -1,0 +1,1 @@
+Add support for Python 3.9 and 3.10

--- a/newsfragments/139.removal.rst
+++ b/newsfragments/139.removal.rst
@@ -1,0 +1,1 @@
+Drop support for Python 3.6

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import (
 extras_require = {
     'test': [
         "hypothesis>=4.18.0,<5",
-        "pytest==5.4.1",
+        "pytest>=6.2.5,<7",
         "pytest-xdist",
         "tox==3.14.6",
     ],
@@ -87,5 +87,6 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,6 @@ setup(
         'Operating System :: MacOS',
         'Operating System :: POSIX',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],

--- a/setup.py
+++ b/setup.py
@@ -86,5 +86,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist=
-    py{36,37,38}-core
-    py{36,37,38}-integration
+    py{37,38}-core
+    py{37,38}-integration
     lint
     docs
-    py{36,37,38}-wheel-cli
+    py{37,38}-wheel-cli
 
 [isort]
 combine_as_imports=True
@@ -29,7 +29,6 @@ commands=
     docs: pytest eth_account
 basepython =
     docs: python
-    py36: python3.6
     py37: python3.7
     py38: python3.8
 extras=
@@ -56,12 +55,6 @@ commands=
     python setup.py sdist bdist_wheel
     /bin/bash -c 'pip install --upgrade "$(ls dist/eth_account-*-py3-none-any.whl)" --progress-bar off'
     python -c "from eth_account import Account"
-
-[testenv:py36-wheel-cli]
-deps={[common-wheel-cli]deps}
-whitelist_externals={[common-wheel-cli]whitelist_externals}
-commands={[common-wheel-cli]commands}
-skip_install=true
 
 [testenv:py37-wheel-cli]
 deps={[common-wheel-cli]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist=
-    py{37,38,39}-core
-    py{37,38,39}-integration
+    py{37,38,39,310}-core
+    py{37,38,39,310}-integration
     lint
     docs
-    py{37,38,39}-wheel-cli
+    py{37,38,39,310}-wheel-cli
 
 [isort]
 combine_as_imports=True
@@ -32,6 +32,7 @@ basepython =
     py37: python3.7
     py38: python3.8
     py39: python3.9
+    py310: python3.10
 extras=
     test
     docs: doc
@@ -70,6 +71,12 @@ commands={[common-wheel-cli]commands}
 skip_install=true
 
 [testenv:py39-wheel-cli]
+deps={[common-wheel-cli]deps}
+whitelist_externals={[common-wheel-cli]whitelist_externals}
+commands={[common-wheel-cli]commands}
+skip_install=true
+
+[testenv:py310-wheel-cli]
 deps={[common-wheel-cli]deps}
 whitelist_externals={[common-wheel-cli]whitelist_externals}
 commands={[common-wheel-cli]commands}

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist=
-    py{37,38}-core
-    py{37,38}-integration
+    py{37,38,39}-core
+    py{37,38,39}-integration
     lint
     docs
-    py{37,38}-wheel-cli
+    py{37,38,39}-wheel-cli
 
 [isort]
 combine_as_imports=True
@@ -31,6 +31,7 @@ basepython =
     docs: python
     py37: python3.7
     py38: python3.8
+    py39: python3.9
 extras=
     test
     docs: doc
@@ -63,6 +64,12 @@ commands={[common-wheel-cli]commands}
 skip_install=true
 
 [testenv:py38-wheel-cli]
+deps={[common-wheel-cli]deps}
+whitelist_externals={[common-wheel-cli]whitelist_externals}
+commands={[common-wheel-cli]commands}
+skip_install=true
+
+[testenv:py39-wheel-cli]
 deps={[common-wheel-cli]deps}
 whitelist_externals={[common-wheel-cli]whitelist_externals}
 commands={[common-wheel-cli]commands}


### PR DESCRIPTION
## What was wrong?

Dependencies have dropped python 3.6 support, so that needs to be dropped here too to be compatible.

## How was it fixed?

Dropped python 3.6 CI integration, and added tests for Python 3.9 and 3.10

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://petpress.net/wp-content/uploads/2019/11/toy-poodle.jpg)
