### PR TITLE
Bump eth keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ crashlytics-build.properties
 fabric.properties
 
 # END JetBrains section
+
+# Jupyter notebook files
+*.ipynb

--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -352,6 +352,7 @@ class Account(object):
         :type signature: hex str or bytes or int
         :returns: address of signer, hex-encoded & checksummed
         :rtype: str
+        :raises: ``eth_keys.exceptions.BadSignature`` if signature is invalid
 
         .. doctest:: python
 

--- a/newsfragments/142.bugfix.rst
+++ b/newsfragments/142.bugfix.rst
@@ -1,0 +1,1 @@
+``recover_message`` now raises an ``eth_keys.exceptions.BadSignature`` error if the v, r, and s points are invalid

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         "bitarray>=1.2.1,<1.3.0",
         "eth-abi>=2.0.0b7,<3",
         "eth-keyfile>=0.5.0,<0.6.0",
-        "eth-keys>=0.2.1,<0.4.0,!=0.3.2",
+        "eth-keys>=0.3.4,<0.4.0",
         "eth-rlp>=0.1.2,<2",
         "eth-utils>=1.3.0,<2",
         "hexbytes>=0.1.0,<1",

--- a/tests/core/test_accounts.py
+++ b/tests/core/test_accounts.py
@@ -16,6 +16,9 @@ from eth_keyfile.keyfile import (
 from eth_keys import (
     keys,
 )
+from eth_keys.exceptions import (
+    BadSignature,
+)
 from eth_utils import (
     is_checksum_address,
     to_bytes,
@@ -283,6 +286,15 @@ def test_eth_account_recover_message(acct):
     message = encode_defunct(text=message_text)
     from_account = acct.recover_message(message, vrs=(v, r, s))
     assert from_account == '0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E'
+
+
+def test_eth_account_recover_message_invalid_signature():
+    private_key = '0x' + '00' * 32
+    message_text = "I♥SF"
+    message = encode_defunct(text=message_text)
+    signed_msg = Account.sign_message(message, private_key)
+    with pytest.raises(BadSignature):
+        Account.recover_message(message, vrs=(signed_msg.v, signed_msg.r, signed_msg.s))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What was wrong?

Needed to pull in the ecrecover point at infinity bugfix from eth-keys.

## How was it fixed?

`eth-keys` v0.3.4 adds the fix, so bumped the dependency requirement and added a test here. I couldn't decide if we should catch the `eth-keys` exception `BadSignature` and re-raise with a different error/message or if we should just leave it. I opted to just leave it for now, but happy to catch if someone feels strongly.

This is PR-ed against a v0.5.x branch that contains the non-breaking changes, so I'll merge this in and release 0.5.7 once this is approved. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/0WQFqtft9RE/hqdefault.jpg)
