### PR TITLE
chore: update eth-abi dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     ]},
     install_requires=[
         "bitarray>=1.2.1,<1.3.0",
-        "eth-abi>=3.0.0,<4",
+        "eth-abi>=4.0,<5.0",
         "eth-keyfile>=0.6.0,<0.7.0",
         "eth-keys>=0.4.0,<0.5",
         "eth-rlp>=0.3.0,<1",


### PR DESCRIPTION
## What was wrong?
`eth-account` had one old pin on `eth-abi` that was missed with recent updates.

## How was it fixed?
Update pin

#### Cute Animal Picture
![cute frogs](https://wallpaperset.com/w/full/3/2/f/149068.jpg)