### PR TITLE
Add create multiple accounts from mnemonic example

### DIFF
--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -281,6 +281,31 @@ class Account(object):
             # They correspond to the same-named methods in Account.*
             # but without the private key argument
         """
+        """
+        Generate multiple accounts from a mnemonic.
+
+        .. CAUTION:: This feature is experimental, unaudited, and likely to change soon
+
+        :param str mnemonic: space-separated list of BIP39 mnemonic seed words
+        :param str passphrase: Optional passphrase used to encrypt the mnemonic
+        :param str account_path: Specify an alternate HD path for deriving the seed using
+            BIP32 HD wallet key derivation.
+        :return: object with methods for signing and encrypting
+        :rtype: LocalAccount
+
+        .. doctest:: python
+
+        >>> from eth_account import Account
+        >>> Account.enable_unaudited_hdwallet_features()
+        >>> iterator = 0
+        >>> for i in range(10):
+        >>> acct = Account.from_mnemonic("health embark april buyer eternal leopard want before nominee head thing tackle", account_path=f"m/44'/60'/0'/0/{iterator}")
+        >>> iterator = iterator + 1
+        >>> acct.address
+
+        .. CAUTION:: For the love of Bob please do not use this mnemonic, it is for testing purposes only.
+
+        """
         if not self._use_unaudited_hdwallet_features:
             raise AttributeError(
                 "The use of the Mnemonic features of Account is disabled by default until "

--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -280,21 +280,32 @@ class Account(object):
             # These methods are also available: sign_message(), sign_transaction(), encrypt()
             # They correspond to the same-named methods in Account.*
             # but without the private key argument
-        """
-        """
-        Generate multiple accounts from a mnemonic.
 
-        .. doctest:: python
+        Or, generate multiple accounts from a mnemonic.
 
-        >>> from eth_account import Account
-        >>> Account.enable_unaudited_hdwallet_features()
-        >>> iterator = 0
-        >>> for i in range(10):
-        >>> acct = Account.from_mnemonic("health embark april buyer eternal leopard want before nominee head thing tackle", account_path=f"m/44'/60'/0'/0/{iterator}")
-        >>> iterator = iterator + 1
-        >>> acct.address
+             >>> from eth_account import Account
+             >>> Account.enable_unaudited_hdwallet_features()
+             >>> iterator = 0
+             >>> for i in range(10):
+             ...     acct = Account.from_mnemonic(
+             ...         "health embark april buyer eternal leopard "
+             ...         "want before nominee head thing tackle",
+             ...         account_path=f"m/44'/60'/0'/0/{iterator}")
+             ...     iterator = iterator + 1
+             ...     acct.address
+             '0x61Cc15522D06983Ac7aADe23f9d5433d38e78195'
+             '0x1240460F6E370f28079E5F9B52f9DcB759F051b7'
+             '0xd30dC9f996539826C646Eb48bb45F6ee1D1474af'
+             '0x47e64beb58c9A469c5eD086aD231940676b44e7C'
+             '0x6D39032ffEF9987988a069F52EFe4d95D0770555'
+             '0x3836A6530D1889853b047799Ecd8827255072e77'
+             '0xed5490dEfF8d8FfAe45cb4066C3daC7C6BFF6a22'
+             '0xf04F9Ff322799253bcC6B12762AD127570a092c5'
+             '0x900F7fa9fbe85BB25b6cdB94Da24D807f7feb213'
+             '0xa248e118b0D19010387b1B768686cd9B473FA137'
 
-        .. CAUTION:: For the love of Bob please do not use this mnemonic, it is for testing purposes only.
+        .. CAUTION:: For the love of Bob please do not use this mnemonic,
+                     it is for testing purposes only.
 
         """
         if not self._use_unaudited_hdwallet_features:

--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -284,15 +284,6 @@ class Account(object):
         """
         Generate multiple accounts from a mnemonic.
 
-        .. CAUTION:: This feature is experimental, unaudited, and likely to change soon
-
-        :param str mnemonic: space-separated list of BIP39 mnemonic seed words
-        :param str passphrase: Optional passphrase used to encrypt the mnemonic
-        :param str account_path: Specify an alternate HD path for deriving the seed using
-            BIP32 HD wallet key derivation.
-        :return: object with methods for signing and encrypting
-        :rtype: LocalAccount
-
         .. doctest:: python
 
         >>> from eth_account import Account

--- a/newsfragments/153.doc.rst
+++ b/newsfragments/153.doc.rst
@@ -1,0 +1,1 @@
+Add example to generate multiple accounts from a mnemonic


### PR DESCRIPTION
## What was wrong?

There were no examples of creating multiple accounts with one mnemonic phrase. 

Issue #

For the love of Bob.

## How was it fixed?

Created an example that increments the creation of 10 accounts in a for loop.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![https://www.boredpanda.com/blog/wp-content/uploads/2014/04/funny-derpy-animals-12.jpg](https://www.boredpanda.com/blog/wp-content/uploads/2014/04/funny-derpy-animals-12.jpg)
