### PR TITLE
Add python version testing to lint jobs, update mypy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,30 +82,48 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: docs
-  lint:
+  py37-lint:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.7
         environment:
-          TOXENV: lint
+          TOXENV: py37-lint
   py37-core:
     <<: *common
     docker:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-core
+  py38-lint:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-lint
   py38-core:
     <<: *common
     docker:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-core
+  py39-lint:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-lint
   py39-core:
     <<: *common
     docker:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-core
+  py310-lint:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-lint
   py310-core:
     <<: *common
     docker:
@@ -165,7 +183,10 @@ workflows:
   test:
     jobs:
       - docs
-      - lint
+      - py37-lint
+      - py38-lint
+      - py39-lint
+      - py310-lint
       - py37-core
       - py38-core
       - py39-core

--- a/newsfragments/155.misc.rst
+++ b/newsfragments/155.misc.rst
@@ -1,0 +1,1 @@
+Update mypy to a version compatible with Python 3.9 and 3.10. Added lint tests against all Python supported versions.

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ extras_require = {
     'lint': [
         "flake8==3.7.9",
         "isort>=4.2.15,<5",
-        "mypy==0.770",
+        "mypy==0.910",
         "pydocstyle>=5.0.0,<6",
     ],
     'doc': [

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist=
     py{37,38,39,310}-core
     py{37,38,39,310}-integration
-    lint
+    py{37,38,39,310}-lint
     docs
     py{37,38,39,310}-wheel-cli
 


### PR DESCRIPTION
## What was wrong?
`pip install -e .[dev]` on Python 3.9 and 3.10 wasn't working because mypy v0.770 isn't compatible.

## How was it fixed?

Updated `mypy`, and added lint testing for all supported versions of Python. This will need to be merged after #156. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://preview.redd.it/mon3dfmrybs01.png?auto=webp&s=6708e59141658a3eb4a7f0d644c6e1766f0ddc20)
