### PR TITLE
Fix doc dependencies

### DIFF
--- a/newsfragments/156.doc.rst
+++ b/newsfragments/156.doc.rst
@@ -1,0 +1,1 @@
+Pin Jinja2 at >=3.0.0,<3.1.0; pin towncrier==19.2.0; open up Sphinx requirement to allow >=1.6.5,<5.

--- a/newsfragments/156.doc.rst
+++ b/newsfragments/156.doc.rst
@@ -1,1 +1,1 @@
-Pin Jinja2 at >=3.0.0,<3.1.0; pin towncrier==19.2.0; open up Sphinx requirement to allow >=1.6.5,<5.
+Pin Jinja2 at >=3.0.0,<3.1.0; pin towncrier==18.5.0; open up Sphinx requirement to allow >=1.6.5,<5.

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ extras_require = {
         "pydocstyle>=5.0.0,<6",
     ],
     'doc': [
-        "Sphinx>=1.6.5,<2",
+        "Sphinx>=1.6.5,<5",
+        "jinja2>=3.0.0,<3.1.0",
         "sphinx_rtd_theme>=0.1.9,<1",
         "towncrier>=19.2.0, <20",
     ],

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,9 @@ extras_require = {
     ],
     'doc': [
         "Sphinx>=1.6.5,<5",
-        "jinja2>=3.0.0,<3.1.0",
+        "jinja2>=3.0.0,<3.1.0",  # jinja2<3.0 or >=3.1.0 cause doc build failures.
         "sphinx_rtd_theme>=0.1.9,<1",
-        "towncrier>=19.2.0, <20",
+        "towncrier==19.2.0",  # towncrier doesn't follow semver
     ],
     'dev': [
         "bumpversion>=0.5.3,<1",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extras_require = {
         "Sphinx>=1.6.5,<5",
         "jinja2>=3.0.0,<3.1.0",  # jinja2<3.0 or >=3.1.0 cause doc build failures.
         "sphinx_rtd_theme>=0.1.9,<1",
-        "towncrier==19.2.0",  # towncrier doesn't follow semver
+        "towncrier==18.5.0",  # towncrier doesn't follow semver
     ],
     'dev': [
         "bumpversion>=0.5.3,<1",


### PR DESCRIPTION
## What was wrong?

Doc builds started failing.

## How was it fixed?

- Added a Jinja2 requirement of >=3.0,<3.1.0. Jinja3.1 breaks our docs with the following error: [ImportError: cannot import name 'contextfunction' from 'jinja2'](https://app.circleci.com/pipelines/github/ethereum/eth-account/197/workflows/41e90459-34c3-4c1e-a143-910b2d849963/jobs/4859)
  - See also: https://github.com/readthedocs/readthedocs.org/issues/9037
- Pinned towncrier to a certain version since they don't follow semver
- Tested higher sphinx versions and opened up the sphinx version requirement

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.saymedia-content.com/.image/t_share/MTc2Mjg2MzI2NTM3NzI1MTE4/cute-caterpillar-photos.jpg)
