### PR TITLE
Exclude venv files from being pulled into dist/ via MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,4 @@ recursive-include eth_account/hdaccount/wordlist *txt
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
+recursive-exclude * venv*

--- a/newsfragments/157.misc.rst
+++ b/newsfragments/157.misc.rst
@@ -1,0 +1,1 @@
+Remove venv files from being packaged in the sdist distribution


### PR DESCRIPTION
## What was wrong?
venv files were being included in `dist`s. 

Closes #150 

## How was it fixed?

recursively excluded venv* directories in MANIFEST.in. 

Note to those in the future: I did have to delete the existing venv directories in order to remove them from the dist dir. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media.istockphoto.com/photos/cute-caterpillar-on-green-leaf-closeup-of-photo-picture-id852063044?k=20&m=852063044&s=170667a&w=0&h=FrCsV4HrJzjEgDILNkb1lvEEpvEsxHbFkZIVAbVxSIQ=)
