### PR TITLE
upgraded bitarray

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         "hdaccount/wordlist/*.txt",
     ]},
     install_requires=[
-        "bitarray>=1.2.1,<1.3.0",
+        "bitarray>=2.4.0,<2.6",
         "eth-abi>=3.0.0,<4",
         "eth-keyfile>=0.6.0,<0.7.0",
         "eth-keys>=0.4.0,<0.5",


### PR DESCRIPTION
## What was wrong?

Issue #148 

## How was it fixed?

Hey @kclowes  I am leaving this as WIP at the moment but I upgraded the bitarray to the 2.4+ version and all the test run. I was going to look more at the code and see if I see anything breaking but I don't think there is. This will help a lot of the install issues on web3.py because wheels are available now for bitarray and no need to build it on install. Thoughts??

