### PR TITLE
Add breaking-change type to towncrier releases

### DIFF
--- a/newsfragments/162.misc.rst
+++ b/newsfragments/162.misc.rst
@@ -1,0 +1,1 @@
+Add breaking change category to release notes

--- a/newsfragments/README.md
+++ b/newsfragments/README.md
@@ -15,6 +15,7 @@ Each file should be named like `<ISSUE>.<TYPE>.rst`, where
 * `internal`
 * `removal`
 * `misc`
+* `breaking`
 
 So for example: `123.feature.rst`, `456.bugfix.rst`
 

--- a/newsfragments/validate_files.py
+++ b/newsfragments/validate_files.py
@@ -15,6 +15,7 @@ ALLOWED_EXTENSIONS = {
     '.misc.rst',
     '.performance.rst',
     '.removal.rst',
+    '.breaking.rst',
 }
 
 ALLOWED_FILES = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,8 @@ showcontent = true
 directory = "misc"
 name = "Miscellaneous changes"
 showcontent = false
+
+[[tool.towncrier.type]]
+directory = "breaking"
+name = "Breaking changes"
+showcontent = true


### PR DESCRIPTION
## What was wrong?
It's nice to have a place to track breaking changes in our release notes.


## How was it fixed?

Added it here and also added it in our python project template repo. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://cdn.cdnparenting.com/articles/2021/09/22115215/1411747946.jpg)
