### PR TITLE
Open up bitarray dependency to allow <3

### DIFF
--- a/newsfragments/163.misc.rst
+++ b/newsfragments/163.misc.rst
@@ -1,0 +1,1 @@
+Open up bitarray dependency to allow >=1.3,<3 so that users have access to wheels in v2.4 if needed.

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         "hdaccount/wordlist/*.txt",
     ]},
     install_requires=[
-        "bitarray>=1.2.1,<1.3.0",
+        "bitarray>=1.2.1,<3",
         "eth-abi>=2.0.0b7,<3",
         "eth-keyfile>=0.5.0,<0.6.0",
         "eth-keys>=0.3.4,<0.4.0",


### PR DESCRIPTION
## What was wrong?

Some users were have trouble installing web3.py because of the strict bitarray dependency requirement. In v2.4.0 bitarray added wheels for all platform types, which should fix the issue. This is the backwards compatible change, and the non-backwards compatible change (`>=2.4,<3`) was PRed against master.

Issue #154, #159

## How was it fixed?

See above.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://rangerplanet.com/wp-content/uploads/2021/10/rabbit-names-4.webp?ezimgfmt=rs:316x211/rscb1/ng:webp/ngcb1)
