### PR TITLE
Prune venvs instead of recursive-exclude

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,4 +9,4 @@ recursive-include eth_account/hdaccount/wordlist *txt
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
-recursive-exclude * venv*
+prune venv*

--- a/newsfragments/157.misc.rst
+++ b/newsfragments/157.misc.rst
@@ -1,1 +1,0 @@
-Remove venv files from being packaged in the sdist distribution

--- a/newsfragments/165.misc.rst
+++ b/newsfragments/165.misc.rst
@@ -1,0 +1,1 @@
+Prune virutal environment files in MANIFEST so they don't get included in the dist

--- a/newsfragments/165.misc.rst
+++ b/newsfragments/165.misc.rst
@@ -1,1 +1,1 @@
-Prune virutal environment files in MANIFEST so they don't get included in the dist
+Prune virtual environment files in MANIFEST so they don't get included in the dist


### PR DESCRIPTION
## What was wrong?

Unwanted/unneeded `venv`s were being included in the package distributions.


## How was it fixed?

used the prune command instead of a recursive-exclude

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2015/09/cute-bunnies-28__605.jpg)
