### PR TITLE
fix tox.ini lint section and mypy issue

### DIFF
--- a/eth_account/hdaccount/deterministic.py
+++ b/eth_account/hdaccount/deterministic.py
@@ -75,8 +75,7 @@ class Node(int):
                 f"{cls} cannot be initialized with value {index}"
             )
 
-        # mypy/typeshed bug requires type ignore: https://github.com/python/typeshed/issues/2686
-        obj = int.__new__(cls, index + cls.OFFSET)  # type: ignore
+        obj = int.__new__(cls, index + cls.OFFSET)
         obj.index = index
         return obj
 

--- a/newsfragments/166.bugfix.rst
+++ b/newsfragments/166.bugfix.rst
@@ -1,0 +1,1 @@
+Enable lint runs again on CI

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ extras_require = {
         "hypothesis>=4.18.0,<5",
         "pytest>=6.2.5,<7",
         "pytest-xdist",
-        "tox==3.14.6",
+        "tox==3.25.0",
     ],
     'lint': [
         "flake8==3.7.9",

--- a/tox.ini
+++ b/tox.ini
@@ -38,13 +38,22 @@ extras=
     docs: doc
 whitelist_externals=make
 
-[testenv:py{37,38,39,310}-lint]
+[common-lint]
 extras=lint
 commands=
     mypy -p eth_account --config-file {toxinidir}/mypy.ini
     flake8 {toxinidir}/eth_account {toxinidir}/tests
     isort --recursive --check-only --diff {toxinidir}/eth_account {toxinidir}/tests
     pydocstyle {toxinidir}/eth_account {toxinidir}/tests
+
+[testenv:py{37,38,39,310}-lint]
+extras={[common-lint]extras}
+commands={[common-lint]commands}
+
+[testenv:lint]
+basepython=python
+extras={[common-lint]extras}
+commands={[common-lint]commands}
 
 [common-wheel-cli]
 deps=wheel

--- a/tox.ini
+++ b/tox.ini
@@ -38,8 +38,7 @@ extras=
     docs: doc
 whitelist_externals=make
 
-[testenv:lint]
-basepython=python
+[testenv:py{37,38,39,310}-lint]
 extras=lint
 commands=
     mypy -p eth_account --config-file {toxinidir}/mypy.ini


### PR DESCRIPTION
## What was wrong?

tox was not running the lint section, as describe [here](https://github.com/ethereum/eth-account/pull/164#issuecomment-1135655506)
Once fixed, a lint error was raised.

## How was it fixed?

The header of the lint section in tox.ini was fixed.

The `# type: ignore` that was causing the mypy error was not needed anymore, since the [underlying issue](https://github.com/python/typeshed/issues/2686) was fixed.

### To-Do

[//]: # (Stay ahead of things, add list items here!)

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://3.bp.blogspot.com/-WIjnBvq0vkk/VfrtN9NNHVI/AAAAAAAAU2A/AmpMnz_EmII/s1600/cute-hilarious-animals-on-pinterest-cute-animal-quotes-funny.jpg)
