### PR TITLE
fix redos-able regex

### DIFF
--- a/eth_account/_utils/structured_data/validation.py
+++ b/eth_account/_utils/structured_data/validation.py
@@ -6,7 +6,7 @@ from eth_utils import (
 
 # Regexes
 IDENTIFIER_REGEX = r"^[a-zA-Z_$][a-zA-Z_$0-9]*$"
-TYPE_REGEX = r"^[a-zA-Z_$][a-zA-Z_$0-9]*(\[([1-9]\d*)*\])*$"
+TYPE_REGEX = r"^[a-zA-Z_$][a-zA-Z_$0-9]*(\[([1-9]\d*\b)*\])*$"
 
 
 def validate_has_attribute(attr_name, dict_data):

--- a/newsfragments/178.bugfix.rst
+++ b/newsfragments/178.bugfix.rst
@@ -1,0 +1,1 @@
+fix DoS-able regex pattern


### PR DESCRIPTION
## What was wrong?

We were notified that a regex we are using was DoS-able
https://en.wikipedia.org/wiki/ReDoS

## How was it fixed?

Fixed it so that the demonstrated vulnerability no longer causes problems.

### To-Do


[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/5199899/175393582-4694bbe6-cf07-408f-aa5e-d137b483b693.png)
