### PR TITLE
v0.5.x fix redos-able regex

### DIFF
--- a/eth_account/_utils/structured_data/validation.py
+++ b/eth_account/_utils/structured_data/validation.py
@@ -6,7 +6,7 @@ from eth_utils import (
 
 # Regexes
 IDENTIFIER_REGEX = r"^[a-zA-Z_$][a-zA-Z_$0-9]*$"
-TYPE_REGEX = r"^[a-zA-Z_$][a-zA-Z_$0-9]*(\[([1-9]\d*)*\])*$"
+TYPE_REGEX = r"^[a-zA-Z_$][a-zA-Z_$0-9]*(\[([1-9]\d*\b)*\])*$"
 
 
 def validate_has_attribute(attr_name, dict_data):

--- a/newsfragments/178.bugfix.rst
+++ b/newsfragments/178.bugfix.rst
@@ -1,0 +1,1 @@
+fix DoS-able regex pattern

--- a/tests/core/test_structured_data_signing.py
+++ b/tests/core/test_structured_data_signing.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 import re
+import time
 
 from eth_abi.exceptions import (
     ABITypeError,
@@ -197,6 +198,29 @@ def test_type_regex(type, valid):
         assert re.match(TYPE_REGEX, type) is not None
     else:
         assert re.match(TYPE_REGEX, type) is None
+
+
+def test_type_regex_for_redos():
+    start = time.time()
+    # len 30 string is long enough to cause > 1 second delay if the regex is bad
+    long = '1' * 30
+    invalid_structured_data_string = f"""{{
+        "types": {{
+            "EIP712Domain": [
+                {{"name": "aaaa", "type": "$[{long}0"}},
+                {{"name": "version", "type": "string"}},
+                {{"name": "chainId", "type": "uint256"}},
+                {{"name": "verifyingContract", "type": "address"}}
+            ]
+        }}
+    }}"""
+
+    with pytest.raises(re.error, match="unterminated character set at position 15"):
+        with pytest.raises(ValidationError, match=f"Invalid Type `$[{long}0` in `EIP712Domain`"):
+            load_and_validate_structured_message(invalid_structured_data_string)
+
+    done = time.time() - start
+    assert done < 1
 
 
 def test_structured_data_invalid_identifier_filtered_by_regex():


### PR DESCRIPTION
## What was wrong?

`v0.5.x` version of PR #178

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/182920018-e585680b-9a80-41cf-8cb7-f4131263c80c.png)
