### PR TITLE
Allow bumpversion to find version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,14 +3,14 @@ current_version = 0.5.8
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}-{stage}.{devnum}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:stage]
 optional_value = stable
 first_value = stable
-values = 
+values =
 	alpha
 	beta
 	stable
@@ -18,5 +18,5 @@ values =
 [bumpversion:part:devnum]
 
 [bumpversion:file:setup.py]
-search = version='{current_version}',
-replace = version='{new_version}',
+search = version="{current_version}",
+replace = version="{new_version}",

--- a/newsfragments/184.misc.rst
+++ b/newsfragments/184.misc.rst
@@ -1,0 +1,1 @@
+Allow bumpversion to find version


### PR DESCRIPTION
## What was wrong?
black autoformatting bit me. bumpversion can't find the version. 



## How was it fixed?

made it look for double quotes. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/ca/3f/3d/ca3f3d1d7685b067902ecb71aca46c5e.jpg)
