### PR TITLE
fix recursive encode type for eip712 signing

### DIFF
--- a/tests/core/test_structured_data_signing.py
+++ b/tests/core/test_structured_data_signing.py
@@ -305,7 +305,7 @@ def test_encode_data_error_messages(primary_type, types, eip712_data, error_type
     )
 )
 def test_get_dependencies_eip712(primary_type, expected, eip712_example_types):
-    assert get_dependencies(primary_type, eip712_example_types) == expected
+    assert get_dependencies(primary_type, eip712_example_types, set()) == set(expected)
 
 
 @pytest.mark.parametrize(
@@ -318,7 +318,7 @@ def test_get_dependencies_eip712(primary_type, expected, eip712_example_types):
 def test_get_dependencies_eip712_with_array(
     primary_type, expected, eip712_example_with_array_types
 ):
-    assert get_dependencies(primary_type, eip712_example_with_array_types) == expected
+    assert get_dependencies(primary_type, eip712_example_with_array_types, set()) == set(expected)
 
 
 @pytest.mark.parametrize(
@@ -332,8 +332,8 @@ def test_get_dependencies_eip712_with_array(
 def test_get_dependencies_eip712_with_multi_array(
     primary_type, expected, eip712_example_with_multi_array_types
 ):
-    assert set(get_dependencies(
-        primary_type, eip712_example_with_multi_array_types)) == set(expected)
+    assert get_dependencies(
+        primary_type, eip712_example_with_multi_array_types, set()) == set(expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
align with https://github.com/MetaMask/eth-sig-util/blob/e293ea9f071a4605205746e97691370229ebc227/src/sign-typed-data.ts#L282

## What was wrong?

Issue #

## How was it fixed?

Summary of approach.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
