### PR TITLE
Ansi-regex bump v0.5.x edition

### DIFF
--- a/newsfragments/129.bugfix.rst
+++ b/newsfragments/129.bugfix.rst
@@ -1,0 +1,1 @@
+bump ansi-regex to 5.0.1 to fix minor ReDos vulnerability

--- a/tests/integration/ethers-cli/package-lock.json
+++ b/tests/integration/ethers-cli/package-lock.json
@@ -386,9 +386,9 @@
       "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "4.2.1",


### PR DESCRIPTION
## What was wrong?
Bump `ansi-regex` version to fix a (minor) ReDos-able regex

This is the v0.5.x version of PR #129 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/184987961-bc897e77-1701-4903-92a7-3e862eef2691.png)
