### PR TITLE
add pytest coverage reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ lint-roll:
 	$(MAKE) lint
 
 test:
-	pytest tests
+	coverage run -m pytest tests
+	coverage report
 
 test-all:
 	tox

--- a/newsfragments/192.internal.rst
+++ b/newsfragments/192.internal.rst
@@ -1,0 +1,1 @@
+add coverage reporting to pytest

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ extras_require = {
         "hypothesis>=4.18.0,<5",
         "pytest>=6.2.5,<7",
         "pytest-xdist",
+        "coverage",
         "tox==3.25.0",
     ],
     "lint": [

--- a/tox.ini
+++ b/tox.ini
@@ -23,11 +23,12 @@ ignore=
 
 [testenv]
 commands=
-    core: pytest {posargs:tests/core}
+    core: coverage run -m pytest {posargs:tests/core}
+    core: coverage report
     integration: pytest {posargs:tests/integration}
     docs: make check-docs
     docs: pytest eth_account
-basepython =
+basepython=
     docs: python
     py37: python3.7
     py38: python3.8


### PR DESCRIPTION
## What was wrong?

Add coverage reporting to pytest
Updated version of PR #78
Credit to @AndreMiras 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/184991194-325c34d2-d70e-4797-9a3a-95cc9f03f9ef.png)
