### PR TITLE
Reduce pbkdf2 iterations speed up tests - updated

### DIFF
--- a/newsfragments/77.performance.rst
+++ b/newsfragments/77.performance.rst
@@ -1,0 +1,1 @@
+Reduce the number of pbkdf2 iterations to speed up tests

--- a/tests/core/test_accounts.py
+++ b/tests/core/test_accounts.py
@@ -645,7 +645,7 @@ def get_encrypt_test_params():
             private_key,
             password,
             None,
-            None,
+            2,
             private_key.to_bytes(),
             'scrypt'
         ),
@@ -653,7 +653,7 @@ def get_encrypt_test_params():
             key,
             password,
             'pbkdf2',
-            None,
+            4,
             key_bytes,
             'pbkdf2'
         ),
@@ -661,7 +661,7 @@ def get_encrypt_test_params():
             key,
             password,
             None,
-            1024,
+            8,
             key_bytes,
             'scrypt'
         ),
@@ -669,7 +669,7 @@ def get_encrypt_test_params():
             key,
             password,
             'pbkdf2',
-            1024,
+            16,
             key_bytes,
             'pbkdf2'
         ),
@@ -677,7 +677,7 @@ def get_encrypt_test_params():
             key,
             password,
             'scrypt',
-            1024,
+            32,
             key_bytes,
             'scrypt'
         ),


### PR DESCRIPTION
Redo of PR #77, because CI wasn't working properly
Credit to @AndreMiras 
## What was wrong?

> Running tests take a bit long.

## How was it fixed?

Reducing the pbkdf2 iterations in the get_encrypt_test_params() fixture.
> This is a first quick fix, but I feel like the test_eth_account_encrypt() test may require a little refactor to quite all the branching it contains.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/185210715-c75ecb09-bf59-4678-9625-dab4fc05a35e.png)
