### PR TITLE
Update circleci img, Remove Sphinx warning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,103 +79,103 @@ jobs:
   docs:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
         environment:
           TOXENV: docs
   py37-lint:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-lint
   py37-core:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-core
   py38-lint:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
         environment:
           TOXENV: py38-lint
   py38-core:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
         environment:
           TOXENV: py38-core
   py39-lint:
     <<: *common
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
         environment:
           TOXENV: py39-lint
   py39-core:
     <<: *common
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
         environment:
           TOXENV: py39-core
   py310-lint:
     <<: *common
     docker:
-      - image: circleci/python:3.10
+      - image: cimg/python:3.10
         environment:
           TOXENV: py310-lint
   py310-core:
     <<: *common
     docker:
-      - image: circleci/python:3.10
+      - image: cimg/python:3.10
         environment:
           TOXENV: py310-core
   py37-integration:
     <<: *integration
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-integration
   py38-integration:
     <<: *integration
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
         environment:
           TOXENV: py38-integration
   py39-integration:
     <<: *integration
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
         environment:
           TOXENV: py39-integration
   py310-integration:
     <<: *integration
     docker:
-      - image: circleci/python:3.10
+      - image: cimg/python:3.10
         environment:
           TOXENV: py310-integration
   py37-wheel-cli:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-wheel-cli
   py38-wheel-cli:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
         environment:
           TOXENV: py38-wheel-cli
   py39-wheel-cli:
     <<: *common
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
         environment:
           TOXENV: py39-wheel-cli
   py310-wheel-cli:
     <<: *common
     docker:
-      - image: circleci/python:3.10
+      - image: cimg/python:3.10
         environment:
           TOXENV: py310-wheel-cli
 workflows:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,7 +82,6 @@ exclude_patterns = [
     "_build",
     "modules.rst",
     "eth_account.internal.rst",
-    "eth_account.hdaccount.rst",
 ]
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/docs/eth_account.hdaccount.rst
+++ b/docs/eth_account.hdaccount.rst
@@ -1,0 +1,31 @@
+:orphan:
+
+eth\_account.hdaccount package
+==============================
+
+Submodules
+----------
+
+eth\_account.hdaccount.deterministic module
+-------------------------------------------
+
+.. automodule:: eth_account.hdaccount.deterministic
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+eth\_account.hdaccount.mnemonic module
+--------------------------------------
+
+.. automodule:: eth_account.hdaccount.mnemonic
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: eth_account.hdaccount
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/newsfragments/194.internal.rst
+++ b/newsfragments/194.internal.rst
@@ -1,0 +1,1 @@
+Use updated circleci Python images, fix Sphinx warning


### PR DESCRIPTION
## What was wrong?
CircleCI has been warning us about using deprecated images, and Sphinx autogenerates a file that we haven't been correctly ignoring. 

## How was it fixed?
- moved circleci images from `circleci` -> `cimg`
- I tried to exclude `docs/eth_account.hdaccount.rst` from being generated, but couldn't figure that out, so I added the auto-generated file to git and added the `:orphan:` tag at the top. This fixes the warning that was being issued on the `make docs` command indicating that `docs/eth_account.hdaccount.rst` wasn't being included in any toctree.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcS4vEbiCRCC7UOvAALvSdCoRC196iGK-Bbtq_vkCZ5Q&s)
