### PR TITLE
Fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ common: &common
         command: pip install --user tox
     - run:
         name: run tox
-        command: ~/.local/bin/tox -r
+        command: python -m tox -r
     - save_cache:
         paths:
           - .hypothesis
@@ -64,7 +64,7 @@ integration: &integration
         command: cd tests/integration/ethers-cli && sudo npm install -g . && cd ../../../
     - run:
         name: run tox
-        command: ~/.local/bin/tox -r
+        command: python -m tox -r
     - save_cache:
         paths:
           - .hypothesis

--- a/newsfragments/197.misc.rst
+++ b/newsfragments/197.misc.rst
@@ -1,0 +1,1 @@
+Fix CI runs


### PR DESCRIPTION
## What was wrong?
CircleCI didn't know how to find the python image, but it didn't fail on my branch.

## How was it fixed?

See PR.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://sbly-web-prod-shareably.netdna-ssl.com/wp-content/uploads/2019/04/09123858/noBFFFX.jpg)
