### PR TITLE
update all references to deprecated eth_abi.encode_abi to eth_abi.encode

### DIFF
--- a/eth_account/_utils/structured_data/hashing.py
+++ b/eth_account/_utils/structured_data/hashing.py
@@ -7,7 +7,7 @@ from operator import (
 )
 
 from eth_abi import (
-    encode_abi,
+    encode,
     is_encodable,
     is_encodable_type,
 )
@@ -202,7 +202,7 @@ def encode_field(types, name, field_type, value):
         else:
             data_types, data_hashes = [], []
 
-        return ("bytes32", keccak(encode_abi(data_types, data_hashes)))
+        return ("bytes32", keccak(encode(data_types, data_hashes)))
 
     # First checking to see if field_type is valid as per abi
     if not is_encodable_type(field_type):
@@ -231,7 +231,7 @@ def encode_data(primary_type, types, data):
         encoded_types.append(type)
         encoded_values.append(value)
 
-    return encode_abi(encoded_types, encoded_values)
+    return encode(encoded_types, encoded_values)
 
 
 def load_and_validate_structured_message(structured_json_string_data):

--- a/newsfragments/200.feature.rst
+++ b/newsfragments/200.feature.rst
@@ -1,0 +1,1 @@
+update all references to deprecated `eth_abi.encode_abi` to `eth_abi.encode`


### PR DESCRIPTION
## What was wrong?

We were still calling the deprecated method `eth_abi.encode_abi`.

## How was it fixed?

Changed all calls to the new `eth_abi.encode`.

### To-Do

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/187746947-64fc84de-104c-44ea-9e5d-9331e70d936d.png)

