### PR TITLE
add newsfragments for dependabot version bumps

### DIFF
--- a/newsfragments/203.misc.rst
+++ b/newsfragments/203.misc.rst
@@ -1,0 +1,1 @@
+bump cross-fetch and @ethersproject/web in /tests/integration/ethers-cli

--- a/newsfragments/204.misc.rst
+++ b/newsfragments/204.misc.rst
@@ -1,0 +1,1 @@
+bump elliptic and @ethersproject/signing-key in /tests/integration/ethers-cli

--- a/newsfragments/206.misc.rst
+++ b/newsfragments/206.misc.rst
@@ -1,0 +1,1 @@
+bump yargs-parser from 16.1.0 to 18.1.3 in /tests/integration/ethers-cli


### PR DESCRIPTION
## What was wrong?
Dependabot bumped some ethers-js dependencies
PRs #203, #204, #206
This is the related newsfragments

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/193934750-c976dcfb-c7db-4fef-9a6f-92836d10337f.png)
