### PR TITLE
Add Python 3.11 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,18 @@ jobs:
       - image: cimg/python:3.10
         environment:
           TOXENV: py310-core
+  py311-lint:
+    <<: *common
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          TOXENV: py311-lint
+  py311-core:
+    <<: *common
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          TOXENV: py311-core
   py37-integration:
     <<: *integration
     docker:
@@ -154,6 +166,12 @@ jobs:
       - image: cimg/python:3.10
         environment:
           TOXENV: py310-integration
+  py311-integration:
+    <<: *integration
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          TOXENV: py311-integration
   py37-wheel-cli:
     <<: *common
     docker:
@@ -178,6 +196,12 @@ jobs:
       - image: cimg/python:3.10
         environment:
           TOXENV: py310-wheel-cli
+  py311-wheel-cli:
+    <<: *common
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          TOXENV: py311-wheel-cli
 workflows:
   version: 2
   test:
@@ -187,15 +211,19 @@ workflows:
       - py38-lint
       - py39-lint
       - py310-lint
+      - py311-lint
       - py37-core
       - py38-core
       - py39-core
       - py310-core
+      - py311-core
       - py37-integration
       - py38-integration
       - py39-integration
       - py310-integration
+      - py311-integration
       - py37-wheel-cli
       - py38-wheel-cli
       - py39-wheel-cli
       - py310-wheel-cli
+      - py311-wheel-cli

--- a/newsfragments/212.feature.rst
+++ b/newsfragments/212.feature.rst
@@ -1,0 +1,1 @@
+Add support for Python 3.11

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     },
     install_requires=[
         "bitarray>=2.4.0,<3",
-        "eth-abi>=3.0.1",
+        "eth-abi>=4.0.0-b.2",
         "eth-keyfile>=0.6.0,<0.7.0",
         "eth-keys>=0.4.0,<0.5",
         "eth-rlp>=0.3.0,<1",

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ commands=
     black {toxinidir}/eth_account {toxinidir}/tests --check
     pydocstyle {toxinidir}/eth_account {toxinidir}/tests
 
-[testenv:py{37,38,39,310}-lint]
+[testenv:py{37,38,39,310,311}-lint]
 extras={[common-lint]extras}
 commands={[common-lint]commands}
 
@@ -68,31 +68,7 @@ commands=
     /bin/bash -c 'pip install --upgrade "$(ls dist/eth_account-*-py3-none-any.whl)" --progress-bar off'
     python -c "from eth_account import Account"
 
-[testenv:py37-wheel-cli]
-deps={[common-wheel-cli]deps}
-allowlist_externals={[common-wheel-cli]allowlist_externals}
-commands={[common-wheel-cli]commands}
-skip_install=true
-
-[testenv:py38-wheel-cli]
-deps={[common-wheel-cli]deps}
-allowlist_externals={[common-wheel-cli]allowlist_externals}
-commands={[common-wheel-cli]commands}
-skip_install=true
-
-[testenv:py39-wheel-cli]
-deps={[common-wheel-cli]deps}
-allowlist_externals={[common-wheel-cli]allowlist_externals}
-commands={[common-wheel-cli]commands}
-skip_install=true
-
-[testenv:py310-wheel-cli]
-deps={[common-wheel-cli]deps}
-allowlist_externals={[common-wheel-cli]allowlist_externals}
-commands={[common-wheel-cli]commands}
-skip_install=true
-
-[testenv:py311-wheel-cli]
+[testenv:py{37,38,39,310,311}-wheel-cli]
 deps={[common-wheel-cli]deps}
 allowlist_externals={[common-wheel-cli]allowlist_externals}
 commands={[common-wheel-cli]commands}

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist=
-    py{37,38,39,310}-core
-    py{37,38,39,310}-integration
-    py{37,38,39,310}-lint
+    py{37,38,39,310,311}-core
+    py{37,38,39,310,311}-integration
+    py{37,38,39,310,311}-lint
     docs
-    py{37,38,39,310}-wheel-cli
+    py{37,38,39,310,311}-wheel-cli
 
 [isort]
 combine_as_imports=True
@@ -33,6 +33,7 @@ basepython =
     py38: python3.8
     py39: python3.9
     py310: python3.10
+    py311: python3.11
 extras=
     test
     docs: doc
@@ -86,6 +87,12 @@ commands={[common-wheel-cli]commands}
 skip_install=true
 
 [testenv:py310-wheel-cli]
+deps={[common-wheel-cli]deps}
+allowlist_externals={[common-wheel-cli]allowlist_externals}
+commands={[common-wheel-cli]commands}
+skip_install=true
+
+[testenv:py311-wheel-cli]
 deps={[common-wheel-cli]deps}
 allowlist_externals={[common-wheel-cli]allowlist_externals}
 commands={[common-wheel-cli]commands}


### PR DESCRIPTION
## What was wrong?
Python 3.11 wasn't supported in eth-account. 

Closes #160 

## How was it fixed?

Added python 3.11 tests to CI, updated node version used in ethers fuzz testing. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://hips.hearstapps.com/clv.h-cdn.co/assets/15/37/1441903721-cupcake-dog.jpg)
