### PR TITLE
Fix CI 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ integration: &integration
         command: pip install --user tox
     - run:
         name: install dependencies (node)
-        command: sudo -E bash tests/integration/ethers-cli/setup_node_v12.sh && sudo apt-get install -y nodejs
+        command: sudo -E bash tests/integration/ethers-cli/setup_node_v18.sh && sudo apt-get install -y nodejs
     - run:
         name: Build ethers-cli
         command: cd tests/integration/ethers-cli && sudo npm install -g . && cd ../../../

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![PyPI version](https://badge.fury.io/py/eth-account.svg)](https://badge.fury.io/py/eth-account)
 [![Python versions](https://img.shields.io/pypi/pyversions/eth-account.svg)](https://pypi.python.org/pypi/eth-account)
 [![Docs build](https://readthedocs.org/projects/eth-account/badge/?version=latest)](http://eth-account.readthedocs.io/en/latest/?badge=latest)
-   
+
 
 Sign Ethereum transactions and messages with local private keys
 
@@ -44,7 +44,7 @@ To run the integration test cases, you need to install node and the custom cli t
 
 ```sh
 apt-get install -y nodejs  # As sudo
-./tests/integration/ethers-cli/setup_node_v12.sh  # As sudo
+./tests/integration/ethers-cli/setup_node_v18.sh  # As sudo
 cd tests/integration/ethers-cli
 npm install -g .  # As sudo
 ```

--- a/newsfragments/217.internal.rst
+++ b/newsfragments/217.internal.rst
@@ -1,0 +1,1 @@
+Upgrade Node from v12.x to v18.x in tests

--- a/tests/integration/ethers-cli/setup_node_v18.sh
+++ b/tests/integration/ethers-cli/setup_node_v18.sh
@@ -21,9 +21,9 @@
 
 
 export DEBIAN_FRONTEND=noninteractive
-SCRSUFFIX="_12.x"
-NODENAME="Node.js 12.x"
-NODEREPO="node_12.x"
+SCRSUFFIX="_18.x"
+NODENAME="Node.js 18.x"
+NODEREPO="node_18.x"
 NODEPKG="nodejs"
 
 print_status() {

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ basepython =
 extras=
     test
     docs: doc
-whitelist_externals=make
+allowlist_externals=make
 
 [common-lint]
 extras=lint
@@ -58,7 +58,7 @@ commands={[common-lint]commands}
 
 [common-wheel-cli]
 deps=wheel
-whitelist_externals=
+allowlist_externals=
     /bin/rm
     /bin/bash
 commands=
@@ -69,24 +69,24 @@ commands=
 
 [testenv:py37-wheel-cli]
 deps={[common-wheel-cli]deps}
-whitelist_externals={[common-wheel-cli]whitelist_externals}
+allowlist_externals={[common-wheel-cli]allowlist_externals}
 commands={[common-wheel-cli]commands}
 skip_install=true
 
 [testenv:py38-wheel-cli]
 deps={[common-wheel-cli]deps}
-whitelist_externals={[common-wheel-cli]whitelist_externals}
+allowlist_externals={[common-wheel-cli]allowlist_externals}
 commands={[common-wheel-cli]commands}
 skip_install=true
 
 [testenv:py39-wheel-cli]
 deps={[common-wheel-cli]deps}
-whitelist_externals={[common-wheel-cli]whitelist_externals}
+allowlist_externals={[common-wheel-cli]allowlist_externals}
 commands={[common-wheel-cli]commands}
 skip_install=true
 
 [testenv:py310-wheel-cli]
 deps={[common-wheel-cli]deps}
-whitelist_externals={[common-wheel-cli]whitelist_externals}
+allowlist_externals={[common-wheel-cli]allowlist_externals}
 commands={[common-wheel-cli]commands}
 skip_install=true


### PR DESCRIPTION
## What was wrong?
Node v12.x is no longer supported by CI.


## How was it fixed?

Updated the node script to use the stable v18.x.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/236x/c5/09/43/c509436a9ef14a0bed6cb54a95e1fa26--crazy-costumes-pet-halloween-costumes.jpg)
