### PR TITLE
remove notices of Draft status for eips 712 and 191, both now in Final

### DIFF
--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -537,15 +537,13 @@ class Account:
         r"""
         Sign the provided message.
 
-        This API supports any messaging format that will encode to EIP-191_ messages.
+        This API supports any messaging format that will encode to EIP-191 messages.
 
-        If you would like historical compatibility with
-        :meth:`w3.eth.sign() <web3.eth.Eth.sign>`
+        If you would like historical compatibility with :meth:`w3.eth.sign() <web3.eth.Eth.sign>`
         you can use :meth:`~eth_account.messages.encode_defunct`.
 
-        Other options are the "validator", or "structured data" standards. (Both of
-        these are in *DRAFT* status currently, so be aware that the implementation is
-        not guaranteed to be stable). You can import all supported message encoders in
+        Other options are the "validator", or "structured data" standards.
+        You can import all supported message encoders in
         ``eth_account.messages``.
 
         :param signable_message: the encoded message for signing

--- a/eth_account/messages.py
+++ b/eth_account/messages.py
@@ -90,7 +90,6 @@ def encode_intended_validator(
     bytes as a primitive, a hex string, or a unicode string.
 
     .. WARNING:: Note that this code has not gone through an external audit.
-        Also, watch for updates to the format, as the EIP is still in DRAFT.
 
     :param validator_address: which on-chain contract is capable of validating this
         message, provided as a checksummed address or in native bytes.
@@ -139,7 +138,6 @@ def encode_structured_data(
 
     .. WARNING:: Note that this code has not gone through an external audit, and
         the test cases are incomplete.
-        Also, watch for updates to the format, as the EIP is still in DRAFT.
 
     :param primitive: the binary message to be signed
     :type primitive: bytes or int or Mapping (eg~ dict )

--- a/newsfragments/222.doc.rst
+++ b/newsfragments/222.doc.rst
@@ -1,0 +1,1 @@
+remove notices of Draft status for eips 712 and 191


### PR DESCRIPTION
## What was wrong?

EIPs 712 and 191 have moved to Final status.

## How was it fixed?

Removed notes saying they were in Draft status.

### To-Do


- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/224851959-82abeca7-15de-4550-aea1-384f5e9cd90d.png)
