### PR TITLE
fix node breaking ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ integration: &integration
         command: sudo -E bash tests/integration/ethers-cli/setup_node_v18.sh && sudo apt-get install -y nodejs
     - run:
         name: Build ethers-cli
-        command: cd tests/integration/ethers-cli && sudo npm install -g . && cd ../../../
+        command: cd tests/integration/ethers-cli && sudo npm install && sudo npm install -g . && cd ../../../
     - run:
         name: run tox
         command: python -m tox -r

--- a/newsfragments/223.internal.rst
+++ b/newsfragments/223.internal.rst
@@ -1,0 +1,1 @@
+pulled full new node_v18 install script

--- a/tests/integration/ethers-cli/setup_node_v18.sh
+++ b/tests/integration/ethers-cli/setup_node_v18.sh
@@ -3,14 +3,14 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js 12.x repo onto a
+# Script to install the NodeSource Node.js 18.x repo onto a
 # Debian or Ubuntu system.
 #
 # Run as root or insert `sudo -E` before `bash`:
 #
-# curl -sL https://deb.nodesource.com/setup_12.x | bash -
+# curl -sL https://deb.nodesource.com/setup_18.x | bash -
 #   or
-# wget -qO- https://deb.nodesource.com/setup_12.x | bash -
+# wget -qO- https://deb.nodesource.com/setup_18.x | bash -
 #
 # CONTRIBUTIONS TO THIS SCRIPT
 #
@@ -93,7 +93,12 @@ node_deprecation_warning() {
           "X${NODENAME}" == "XNode.js 7.x" ||
           "X${NODENAME}" == "XNode.js 8.x LTS Carbon" ||
           "X${NODENAME}" == "XNode.js 9.x" ||
-          "X${NODENAME}" == "XNode.js 11.x" ]]; then
+          "X${NODENAME}" == "XNode.js 10.x" ||
+          "X${NODENAME}" == "XNode.js 11.x" || 
+          "X${NODENAME}" == "XNode.js 12.x" ||
+          "X${NODENAME}" == "XNode.js 13.x" ||
+          "X${NODENAME}" == "XNode.js 15.x" ||
+          "X${NODENAME}" == "XNode.js 17.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -105,8 +110,10 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 LTS \"Dubnium\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_12.x — Node.js 12 LTS \"Erbium\"${normal}
+   * ${green}https://deb.nodesource.com/setup_14.x — Node.js 14 \"Fermium\"${normal}
+   * ${green}https://deb.nodesource.com/setup_16.x — Node.js 16 \"Gallium\"${normal}
+   * ${green}https://deb.nodesource.com/setup_18.x — Node.js 18 LTS \"Hydrogen\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_19.x — Node.js 19 \"Nineteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -133,8 +140,11 @@ This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used t
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 LTS \"Dubnium\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_12.x — Node.js 12 LTS \"Erbium\"${normal}
+   * ${green}https://deb.nodesource.com/setup_14.x — Node.js 14 \"Fermium\"${normal}
+   * ${green}https://deb.nodesource.com/setup_16.x — Node.js 16 \"Gallium\"${normal}
+   * ${green}https://deb.nodesource.com/setup_18.x — Node.js 18 LTS \"Hydrogen\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_19.x — Node.js 19 \"Nineteen\"${normal} (current)
+
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
 
@@ -214,54 +224,77 @@ check_alt() {
     fi
 }
 
-check_alt "SolydXK"       "solydxk-9" "Debian" "stretch"
-check_alt "Kali"          "sana"     "Debian" "jessie"
-check_alt "Kali"          "kali-rolling" "Debian" "jessie"
-check_alt "Sparky Linux"  "Tyche"    "Debian" "stretch"
-check_alt "Sparky Linux"  "Nibiru"   "Debian" "buster"
-check_alt "MX Linux 17"   "Horizon"  "Debian" "stretch"
-check_alt "MX Linux 18"   "Continuum" "Debian" "stretch"
-check_alt "MX Linux 19"   "patito feo" "Debian" "buster"
-check_alt "Linux Mint"    "maya"     "Ubuntu" "precise"
-check_alt "Linux Mint"    "qiana"    "Ubuntu" "trusty"
-check_alt "Linux Mint"    "rafaela"  "Ubuntu" "trusty"
-check_alt "Linux Mint"    "rebecca"  "Ubuntu" "trusty"
-check_alt "Linux Mint"    "rosa"     "Ubuntu" "trusty"
-check_alt "Linux Mint"    "sarah"    "Ubuntu" "xenial"
-check_alt "Linux Mint"    "serena"   "Ubuntu" "xenial"
-check_alt "Linux Mint"    "sonya"    "Ubuntu" "xenial"
-check_alt "Linux Mint"    "sylvia"   "Ubuntu" "xenial"
-check_alt "Linux Mint"    "tara"     "Ubuntu" "bionic"
-check_alt "Linux Mint"    "tessa"    "Ubuntu" "bionic"
-check_alt "Linux Mint"    "tina"     "Ubuntu" "bionic"
-check_alt "Linux Mint"    "tricia"   "Ubuntu" "bionic"
-check_alt "LMDE"          "betsy"    "Debian" "jessie"
-check_alt "LMDE"          "cindy"    "Debian" "stretch"
-check_alt "elementaryOS"  "luna"     "Ubuntu" "precise"
-check_alt "elementaryOS"  "freya"    "Ubuntu" "trusty"
-check_alt "elementaryOS"  "loki"     "Ubuntu" "xenial"
-check_alt "elementaryOS"  "juno"     "Ubuntu" "bionic"
-check_alt "elementaryOS"  "hera"     "Ubuntu" "bionic"
-check_alt "Trisquel"      "toutatis" "Ubuntu" "precise"
-check_alt "Trisquel"      "belenos"  "Ubuntu" "trusty"
-check_alt "Trisquel"      "flidas"   "Ubuntu" "xenial"
-check_alt "Uruk GNU/Linux" "lugalbanda" "Ubuntu" "xenial"
-check_alt "BOSS"          "anokha"   "Debian" "wheezy"
-check_alt "BOSS"          "anoop"    "Debian" "jessie"
-check_alt "BOSS"          "drishti"  "Debian" "stretch"
-check_alt "bunsenlabs"    "bunsen-hydrogen" "Debian" "jessie"
-check_alt "bunsenlabs"    "helium"   "Debian" "stretch"
-check_alt "Tanglu"        "chromodoris" "Debian" "jessie"
-check_alt "PureOS"        "green"    "Debian" "sid"
-check_alt "Devuan"        "jessie"   "Debian" "jessie"
-check_alt "Devuan"        "ascii"    "Debian" "stretch"
-check_alt "Devuan"        "beowulf"  "Debian" "buster"
-check_alt "Devuan"        "ceres"    "Debian" "sid"
-check_alt "Deepin"        "panda"    "Debian" "sid"
-check_alt "Deepin"        "unstable" "Debian" "sid"
-check_alt "Deepin"        "stable"   "Debian" "buster"
-check_alt "Pardus"        "onyedi"   "Debian" "stretch"
-check_alt "Liquid Lemur"  "lemur-3"  "Debian" "stretch"
+check_alt "Astra Linux"    "orel"            "Debian"        "stretch"
+check_alt "BOSS"           "anokha"          "Debian"        "wheezy"
+check_alt "BOSS"           "anoop"           "Debian"        "jessie"
+check_alt "BOSS"           "drishti"         "Debian"        "stretch"
+check_alt "BOSS"           "unnati"          "Debian"        "buster"
+check_alt "BOSS"           "urja"            "Debian"        "bullseye"
+check_alt "bunsenlabs"     "bunsen-hydrogen" "Debian"        "jessie"
+check_alt "bunsenlabs"     "helium"          "Debian"        "stretch"
+check_alt "bunsenlabs"     "lithium"         "Debian"        "buster"
+check_alt "Devuan"         "jessie"          "Debian"        "jessie"
+check_alt "Devuan"         "ascii"           "Debian"        "stretch"
+check_alt "Devuan"         "beowulf"         "Debian"        "buster"
+check_alt "Devuan"         "chimaera"        "Debian"        "bullseye"
+check_alt "Devuan"         "ceres"           "Debian"        "sid"
+check_alt "Deepin"         "panda"           "Debian"        "sid"
+check_alt "Deepin"         "unstable"        "Debian"        "sid"
+check_alt "Deepin"         "stable"          "Debian"        "buster"
+check_alt "Deepin"         "apricot"         "Debian"        "buster"
+check_alt "elementaryOS"   "luna"            "Ubuntu"        "precise"
+check_alt "elementaryOS"   "freya"           "Ubuntu"        "trusty"
+check_alt "elementaryOS"   "loki"            "Ubuntu"        "xenial"
+check_alt "elementaryOS"   "juno"            "Ubuntu"        "bionic"
+check_alt "elementaryOS"   "hera"            "Ubuntu"        "bionic"
+check_alt "elementaryOS"   "odin"            "Ubuntu"        "focal"
+check_alt "elementaryOS"   "jolnir"          "Ubuntu"        "focal"
+check_alt "Kali"           "sana"            "Debian"        "jessie"
+check_alt "Kali"           "kali-rolling"    "Debian"        "bullseye"
+check_alt "Linux Mint"     "maya"            "Ubuntu"        "precise"
+check_alt "Linux Mint"     "qiana"           "Ubuntu"        "trusty"
+check_alt "Linux Mint"     "rafaela"         "Ubuntu"        "trusty"
+check_alt "Linux Mint"     "rebecca"         "Ubuntu"        "trusty"
+check_alt "Linux Mint"     "rosa"            "Ubuntu"        "trusty"
+check_alt "Linux Mint"     "sarah"           "Ubuntu"        "xenial"
+check_alt "Linux Mint"     "serena"          "Ubuntu"        "xenial"
+check_alt "Linux Mint"     "sonya"           "Ubuntu"        "xenial"
+check_alt "Linux Mint"     "sylvia"          "Ubuntu"        "xenial"
+check_alt "Linux Mint"     "tara"            "Ubuntu"        "bionic"
+check_alt "Linux Mint"     "tessa"           "Ubuntu"        "bionic"
+check_alt "Linux Mint"     "tina"            "Ubuntu"        "bionic"
+check_alt "Linux Mint"     "tricia"          "Ubuntu"        "bionic"
+check_alt "Linux Mint"     "ulyana"          "Ubuntu"        "focal"
+check_alt "Linux Mint"     "ulyssa"          "Ubuntu"        "focal"
+check_alt "Linux Mint"     "uma"             "Ubuntu"        "focal"
+check_alt "Linux Mint"     "una"             "Ubuntu"        "focal"
+check_alt "Linux Mint"     "vanessa"         "Ubuntu"        "jammy"
+check_alt "Linux Mint"     "vera"            "Ubuntu"        "jammy"
+check_alt "Liquid Lemur"   "lemur-3"         "Debian"        "stretch"
+check_alt "LMDE"           "betsy"           "Debian"        "jessie"
+check_alt "LMDE"           "cindy"           "Debian"        "stretch"
+check_alt "LMDE"           "debbie"          "Debian"        "buster"
+check_alt "LMDE"           "elsie"           "Debian"        "bullseye"
+check_alt "MX Linux 17"    "Horizon"         "Debian"        "stretch"
+check_alt "MX Linux 18"    "Continuum"       "Debian"        "stretch"
+check_alt "MX Linux 19"    "patito feo"      "Debian"        "buster"
+check_alt "MX Linux 21"    "wildflower"      "Debian"        "bullseye"
+check_alt "Pardus"         "onyedi"          "Debian"        "stretch"
+check_alt "Parrot"         "ara"             "Debian"        "bullseye"
+check_alt "PureOS"         "green"           "Debian"        "sid"
+check_alt "PureOS"         "amber"           "Debian"        "buster"
+check_alt "PureOS"         "byzantium"       "Debian"        "bullseye"
+check_alt "SolydXK"        "solydxk-9"       "Debian"        "stretch"
+check_alt "Sparky Linux"   "Tyche"           "Debian"        "stretch"
+check_alt "Sparky Linux"   "Nibiru"          "Debian"        "buster"
+check_alt "Sparky Linux"   "Po-Tolo"         "Debian"        "bullseye"
+check_alt "Tanglu"         "chromodoris"     "Debian"        "jessie"
+check_alt "Trisquel"       "toutatis"        "Ubuntu"        "precise"
+check_alt "Trisquel"       "belenos"         "Ubuntu"        "trusty"
+check_alt "Trisquel"       "flidas"          "Ubuntu"        "xenial"
+check_alt "Trisquel"       "etiona"          "Ubuntu"        "bionic"
+check_alt "Ubilinux"       "dolcetto"        "Debian"        "stretch"
+check_alt "Uruk GNU/Linux" "lugalbanda"      "Ubuntu"        "xenial"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."
@@ -297,28 +330,35 @@ if [ -f "/etc/apt/sources.list.d/chris-lea-node_js-$DISTRO.list" ]; then
 fi
 
 print_status 'Adding the NodeSource signing key to your keyring...'
+keyring='/usr/share/keyrings'
+node_key_url="https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
+local_node_key="$keyring/nodesource.gpg"
 
 if [ -x /usr/bin/curl ]; then
-    exec_cmd 'curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -'
+    exec_cmd "curl -s $node_key_url | gpg --dearmor | tee $local_node_key >/dev/null"
 else
-    exec_cmd 'wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -'
+    exec_cmd "wget -q -O - $node_key_url | gpg --dearmor | tee $local_node_key >/dev/null"
 fi
 
 print_status "Creating apt sources list file for the NodeSource ${NODENAME} repo..."
 
-exec_cmd "echo 'deb https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
-exec_cmd "echo 'deb-src https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb [signed-by=$local_node_key] https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb-src [signed-by=$local_node_key] https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
 
 print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
 
+yarn_site='https://dl.yarnpkg.com/debian'
+yarn_key_url="$yarn_site/pubkey.gpg"
+local_yarn_key="$keyring/yarnkey.gpg"
+
 print_status """Run \`${bold}sudo apt-get install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm
 ## You may also need development tools to build native addons:
      sudo apt-get install gcc g++ make
 ## To install the Yarn package manager, run:
-     curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-     echo \"deb https://dl.yarnpkg.com/debian/ stable main\" | sudo tee /etc/apt/sources.list.d/yarn.list
+     curl -sL $yarn_key_url | gpg --dearmor | sudo tee $local_yarn_key >/dev/null
+     echo \"deb [signed-by=$local_yarn_key] $yarn_site stable main\" | sudo tee /etc/apt/sources.list.d/yarn.list
      sudo apt-get update && sudo apt-get install yarn
 """
 


### PR DESCRIPTION
## What was wrong?

`npm install -g .` seems to have changed function. It creates a symlink back to the local folder (`tests/integration/ethers-cli` in this case) rather than installing all the dependencies locally.

## How was it fixed?

Added a local `npm install` that actually installs dependencies. Also pulled a new npm install script in.

### To-Do

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/225383152-a11ccabc-93ec-4d27-81c3-270e6114db73.png)
