### PR TITLE
bump docs versions and update .readthedocs.yml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,2 +1,5 @@
-build:
-    image: latest
+version: 2
+
+python:
+  install:
+  - requirements: requirements-docs.txt

--- a/newsfragments/224.internal.rst
+++ b/newsfragments/224.internal.rst
@@ -1,0 +1,1 @@
+bump versions for docs dependencies

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,8 @@ extras_require = {
         "black>=22,<23",
     ],
     "doc": [
-        "Sphinx>=1.6.5,<5",
-        "jinja2>=3.0.0,<3.1.0",  # jinja2<3.0 or >=3.1.0 cause doc build failures.
-        "sphinx_rtd_theme>=0.1.9,<1",
+        "sphinx>=5.0.0",
+        "sphinx_rtd_theme>=1.0.0",
         "towncrier>=21,<22",
     ],
     "dev": [


### PR DESCRIPTION
## What was wrong?

Docs dependencies were scoped low

## How was it fixed?

Raised lower bar, removed upper pin

### To-Do

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/226728298-d8802088-9794-4f23-97bb-13d8aa7151cc.png)
