### PR TITLE
Add encode typed data

### DIFF
--- a/eth_account/_utils/encode_typed_data.py
+++ b/eth_account/_utils/encode_typed_data.py
@@ -1,0 +1,326 @@
+from typing import (
+    Any,
+    Dict,
+    List,
+    Tuple,
+)
+
+from eth_abi import (
+    encode,
+)
+from eth_utils import (
+    is_hexstr,
+    keccak,
+    to_bytes,
+)
+
+
+def _get_EIP712_solidity_types():
+    types = ["bool", "address", "string", "bytes"]
+    ints = [f"int{(x + 1) * 8}" for x in range(32)]
+    uints = [f"uint{(x + 1) * 8}" for x in range(32)]
+    bytes_ = [f"bytes{x + 1}" for x in range(32)]
+    return types + ints + uints + bytes_
+
+
+EIP712_SOLIDITY_TYPES = _get_EIP712_solidity_types()
+
+
+def _is_array_type(type_: str) -> bool:
+    return type_.endswith("]")
+
+
+# strip all brackets: Person[][] -> Person
+def _parse_core_array_type(type_: str) -> str:
+    if _is_array_type(type_):
+        type_ = type_[: type_.index("[")]
+    return type_
+
+
+# strip outermost brackets: Person[][] -> Person[]
+def _parse_inner_array_type(type_: str) -> str:
+    if _is_array_type(type_):
+        type_ = type_[: type_.rindex("[")]
+    return type_
+
+
+def _get_primary_type(types: Dict[str, List[Dict[str, str]]]) -> str:
+    custom_types = set(types.keys())
+    custom_types_that_are_deps = set()
+
+    for type in custom_types:
+        type_fields = types[type]
+        for field in type_fields:
+            parsed_type = _parse_core_array_type(field["type"])
+            if parsed_type in custom_types and parsed_type != type:
+                custom_types_that_are_deps.add(parsed_type)
+
+    primary_type = list(custom_types.difference(custom_types_that_are_deps))
+    if len(primary_type) == 1:
+        return primary_type[0]
+    else:
+        raise ValueError("Unable to determine primary type")
+
+
+def encode_field(
+    types: Dict[str, List[Dict[str, str]]],
+    name: str,
+    type_: str,
+    value: Any,
+) -> Tuple[str, bytes]:
+    if type_ in types.keys():
+        # type is a custom type
+        if value is None:
+            return (
+                "bytes32",
+                b"\x00" * 32,
+            )
+        else:
+            return (
+                "bytes32",
+                keccak(encode_data(type_, types, value)),
+            )
+
+    if type_ in ["string", "bytes"] and value is None:
+        return (
+            "bytes32",
+            b"",
+        )
+
+    # None is allowed only for custom and dynamic types
+    if value is None:
+        raise ValueError(f"missing value for field {name} of type {type_}")
+
+    if type_ == "bytes":
+        if is_hexstr(value):
+            value = to_bytes(hexstr=value)
+        else:
+            value = to_bytes(value)
+        return ("bytes32", keccak(value))
+
+    if type_ == "string":
+        if isinstance(value, int):
+            value = to_bytes(value)
+        else:
+            value = to_bytes(text=value)
+        return ("bytes32", keccak(value))
+
+    if _is_array_type(type_):
+        type_ = _parse_inner_array_type(type_)
+        type_value_pairs = [encode_field(types, name, type_, item) for item in value]
+        data_types, data_hashes = zip(*type_value_pairs)
+        return ("bytes32", keccak(encode(data_types, data_hashes)))
+
+    return (type_, value)
+
+
+def find_type_dependencies(type_, types, results=None):
+    if results is None:
+        results = set()
+
+    # a type must be a string
+    if not isinstance(type_, str):
+        raise ValueError(
+            "Invalid find_type_dependencies input: expected string, got "
+            f"{type_} of type {type(type_)}"
+        )
+    # get core type if it's an array type
+    type_ = _parse_core_array_type(type_)
+
+    # don't look for dependencies of solidity types
+    if type_ in EIP712_SOLIDITY_TYPES:
+        return results
+
+    # found a type that isn't defined
+    if type_ not in types:
+        raise ValueError(f"No definition of type {type_}")
+
+    # found a type that's already been added
+    if type_ in results:
+        return results
+
+    results.add(type_)
+
+    for field in types[type_]:
+        find_type_dependencies(field["type"], types, results)
+    return results
+
+
+def encode_type(type_: str, types: Dict[str, List[Dict[str, str]]]) -> str:
+    result = ""
+    unsorted_deps = find_type_dependencies(type_, types)
+    if type_ in unsorted_deps:
+        unsorted_deps.remove(type_)
+
+    deps = [type_] + sorted(list(unsorted_deps))
+    for type_ in deps:
+        children_list = []
+        for child in types[type_]:
+            child_type = child["type"]
+            child_name = child["name"]
+            children_list.append(f"{child_type} {child_name}")
+
+        result += f"{type_}({','.join(children_list)})"
+
+    return result
+
+
+def hash_type(type_: str, types: Dict[str, List[Dict[str, str]]]) -> bytes:
+    return keccak(text=encode_type(type_, types))
+
+
+def encode_data(
+    type_: str,
+    types: Dict[str, List[Dict[str, str]]],
+    data: Dict[str, Any],
+) -> bytes:
+    encoded_types = ["bytes32"]
+    encoded_values = [hash_type(type_, types)]
+
+    for field in types[type_]:
+        type, value = encode_field(
+            types,
+            field["name"],
+            field["type"],
+            data.get(field["name"]),
+        )
+        encoded_types.append(type)
+        encoded_values.append(value)
+
+    return encode(encoded_types, encoded_values)
+
+
+def hash_struct(
+    type_: str,
+    types: Dict[str, List[Dict[str, str]]],
+    data: Dict[str, Any],
+) -> bytes:
+    encoded = encode_data(type_, types, data)
+    hashed = keccak(encoded)
+    return hashed
+
+
+def hash_domain(domain_data: Dict[str, Any]) -> bytes:
+    EIP712_domain_map = {
+        "name": {"name": "name", "type": "string"},
+        "version": {"name": "version", "type": "string"},
+        "chainId": {"name": "chainId", "type": "uint256"},
+        "verifyingContract": {"name": "verifyingContract", "type": "address"},
+        "salt": {"name": "salt", "type": "bytes32"},
+    }
+
+    for k in domain_data.keys():
+        if k not in EIP712_domain_map.keys():
+            raise ValueError(f"Invalid domain key: {k}")
+
+    domain_types = {
+        "EIP712Domain": [
+            EIP712_domain_map[k] for k in domain_data.keys() if k in domain_data
+        ]
+    }
+
+    return hash_struct("EIP712Domain", domain_types, domain_data)
+
+
+def hash_EIP712_message(
+    message_types: Dict[str, List[Dict[str, str]]],
+    message_data: Dict[str, Any],
+) -> bytes:
+    primary_type = _get_primary_type(message_types)
+    return keccak(encode_data(primary_type, message_types, message_data))
+
+
+"""
+
+def _fixInt(v):
+    if type(v) == str:
+        base = 16 if "0x" in v else 10
+        return int(v, base)
+    elif type(v) == int:
+        return v
+    return None
+
+
+def _fixByte(v):
+    if type(v) == str and len(v) % 2 == 0:
+        newValue = v
+        if "0x" in v:
+            newValue = newValue.replace("0x", "")
+        return bytes.fromhex(newValue)
+    elif type(v) == list:
+        testList = [0 <= _v <= 255 for _v in v]
+        if all(testList):
+            return bytes(v)
+    return None
+
+
+def _fix(v, tp, types):
+    isArray = "[" in tp and "]" in tp
+    if isArray:
+        tp = tp[: tp.index("[")]
+    if tp in [
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+        "uint128",
+        "uint256",
+        "uint512",
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "int128",
+        "int256",
+        "int512",
+    ]:
+        if isArray:
+            r = []
+            for i, _ in enumerate(v):
+                newV = _fixInt(v[i])
+                if newV is not None:
+                    r.append(newV)
+                else:
+                    return None
+            return r
+        else:
+            return _fixInt(v)
+
+    elif tp in ["bytes1", "bytes32", "bytes"]:
+        if isArray:
+            r = []
+            for i, _ in enumerate(v):
+                newV = _fixByte(v[i])
+                if newV is not None:
+                    r.append(newV)
+                else:
+                    return None
+            return r
+        else:
+            return _fixByte(v)
+    elif tp == "address":
+        return v
+    elif tp == "string":
+        return v
+    else:  # custom type
+        if not (tp in types):
+            return None
+        newTypes = types[tp]
+        if isArray:
+            r = []
+            for i, _ in enumerate(v):
+                newV = {}
+                for tInfo in newTypes:
+                    key = tInfo["name"]
+                    tp = tInfo["type"]
+                    newV[key] = _fix(v[i][key], tp, types)
+                r.append(newV)
+            return r
+        else:
+            newV = {}
+            for tInfo in newTypes:
+                key = tInfo["name"]
+                tp = tInfo["type"]
+                newV[key] = _fix(v[key], tp, types)
+            return newV
+"""

--- a/eth_account/_utils/encode_typed_data/__init__.py
+++ b/eth_account/_utils/encode_typed_data/__init__.py
@@ -1,0 +1,4 @@
+from .encoding_and_hashing import (
+    hash_domain,
+    hash_EIP712_message,
+)

--- a/eth_account/_utils/encode_typed_data/__init__.py
+++ b/eth_account/_utils/encode_typed_data/__init__.py
@@ -1,4 +1,4 @@
 from .encoding_and_hashing import (
     hash_domain,
-    hash_EIP712_message,
+    hash_eip712_message,
 )

--- a/eth_account/_utils/encode_typed_data/helpers.py
+++ b/eth_account/_utils/encode_typed_data/helpers.py
@@ -1,0 +1,61 @@
+from typing import (
+    Any,
+)
+
+
+def _get_EIP712_solidity_types():
+    types = ["bool", "address", "string", "bytes"]
+    ints = [f"int{(x + 1) * 8}" for x in range(32)]
+    uints = [f"uint{(x + 1) * 8}" for x in range(32)]
+    bytes_ = [f"bytes{x + 1}" for x in range(32)]
+    return types + ints + uints + bytes_
+
+
+EIP712_SOLIDITY_TYPES = _get_EIP712_solidity_types()
+
+
+def is_array_type(type_: str) -> bool:
+    return type_.endswith("]")
+
+
+# strip all brackets: Person[][] -> Person
+def parse_core_array_type(type_: str) -> str:
+    if is_array_type(type_):
+        type_ = type_[: type_.index("[")]
+    return type_
+
+
+# strip only last set of brackets: Person[3][1] -> Person[3]
+def parse_parent_array_type(type_: str) -> str:
+    if is_array_type(type_):
+        type_ = type_[: type_.rindex("[")]
+    return type_
+
+
+def coerce_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    elif isinstance(value, int):
+        if value == 0:
+            return False
+        elif value == 1:
+            return True
+        else:
+            raise TypeError(f"Cannot coerce int '{value}' to bool")
+    elif isinstance(value, bytes):
+        if value == b"\x00":
+            return False
+        elif value == b"\x01":
+            return True
+        else:
+            raise TypeError(f"Cannot coerce bytes '{value!r}' to bool")
+    elif isinstance(value, str):
+        if value.lower() in ["false", "0", "0x0"]:
+            return False
+        elif value.lower() in ["true", "1", "0x1"]:
+            return True
+        else:
+            raise TypeError(f"Cannot coerce string '{value}' to bool")
+
+    else:
+        raise TypeError(f"Cannot coerce '{value}' of type '{type(value)}' to bool")

--- a/eth_account/_utils/encode_typed_data/helpers.py
+++ b/eth_account/_utils/encode_typed_data/helpers.py
@@ -2,20 +2,28 @@ from typing import (
     Any,
 )
 
+from eth_utils import (
+    is_hexstr,
+)
 
-def _get_EIP712_solidity_types():
-    types = ["bool", "address", "string", "bytes"]
+
+def _get_eip712_solidity_types():
+    types = ["bool", "address", "string", "bytes", "uint", "int"]
     ints = [f"int{(x + 1) * 8}" for x in range(32)]
     uints = [f"uint{(x + 1) * 8}" for x in range(32)]
     bytes_ = [f"bytes{x + 1}" for x in range(32)]
     return types + ints + uints + bytes_
 
 
-EIP712_SOLIDITY_TYPES = _get_EIP712_solidity_types()
+EIP712_SOLIDITY_TYPES = _get_eip712_solidity_types()
 
 
 def is_array_type(type_: str) -> bool:
     return type_.endswith("]")
+
+
+def is_0x_prefixed_hexstr(value: Any) -> bool:
+    return is_hexstr(value) and value.startswith("0x")
 
 
 # strip all brackets: Person[][] -> Person
@@ -30,32 +38,3 @@ def parse_parent_array_type(type_: str) -> str:
     if is_array_type(type_):
         type_ = type_[: type_.rindex("[")]
     return type_
-
-
-def coerce_bool(value: Any) -> bool:
-    if isinstance(value, bool):
-        return value
-    elif isinstance(value, int):
-        if value == 0:
-            return False
-        elif value == 1:
-            return True
-        else:
-            raise TypeError(f"Cannot coerce int '{value}' to bool")
-    elif isinstance(value, bytes):
-        if value == b"\x00":
-            return False
-        elif value == b"\x01":
-            return True
-        else:
-            raise TypeError(f"Cannot coerce bytes '{value!r}' to bool")
-    elif isinstance(value, str):
-        if value.lower() in ["false", "0", "0x0"]:
-            return False
-        elif value.lower() in ["true", "1", "0x1"]:
-            return True
-        else:
-            raise TypeError(f"Cannot coerce string '{value}' to bool")
-
-    else:
-        raise TypeError(f"Cannot coerce '{value}' of type '{type(value)}' to bool")

--- a/eth_account/messages.py
+++ b/eth_account/messages.py
@@ -326,3 +326,124 @@ def defunct_hash_message(
     signable = encode_defunct(primitive, hexstr=hexstr, text=text)
     hashed = _hash_eip191_message(signable)
     return HexBytes(hashed)
+
+
+def _fixInt(v):
+    if type(v) == str:
+        base = 16 if '0x' in v else 10
+        return int(v, base)
+    elif type(v) == int:
+        return v
+    return None
+
+
+def _fixByte(v):
+    if type(v) == str and len(v) % 2 == 0:
+        newValue = v
+        if '0x' in v:
+            newValue = newValue.replace('0x', '')
+        return bytes.fromhex(newValue)
+    elif type(v) == list:
+        testList = [0 <= _v <= 255 for _v in v]
+        if all(testList):
+            return bytes(v)
+    return None
+
+
+def _fix(v, tp, types):
+    isArray = '[' in tp and ']' in tp
+    if isArray:
+        tp = tp[:tp.index('[')]
+    if tp in ['uint8', 'uint16', 'uint32', 'uint64', 'uint128', 'uint256', 'uint512', 'int8', 'int16', 'int32', 'int64',
+              'int128', 'int256', 'int512']:
+        if isArray:
+            r = []
+            for i, _ in enumerate(v):
+                newV = _fixInt(v[i])
+                if newV is not None:
+                    r.append(newV)
+                else:
+                    return None
+            return r
+        else:
+            return _fixInt(v)
+
+    elif tp in ['bytes1', 'bytes32', 'bytes']:
+        if isArray:
+            r = []
+            for i, _ in enumerate(v):
+                newV = _fixByte(v[i])
+                if newV is not None:
+                    r.append(newV)
+                else:
+                    return None
+            return r
+        else:
+            return _fixByte(v)
+    elif tp == 'address':
+        return v
+    elif tp == 'string':
+        return v
+    else:  # custom type
+        if not (tp in types):
+            return None
+        newTypes = types[tp]
+        if isArray:
+            r = []
+            for i, _ in enumerate(v):
+                newV = {}
+                for tInfo in newTypes:
+                    key = tInfo['name']
+                    tp = tInfo['type']
+                    newV[key] = _fix(v[i][key], tp, types)
+                r.append(newV)
+            return r
+        else:
+            newV = {}
+            for tInfo in newTypes:
+                key = tInfo['name']
+                tp = tInfo['type']
+                newV[key] = _fix(v[key], tp, types)
+            return newV
+
+
+def _getPrimaryType(types: dict, values: dict):
+    primaryType = ''
+    for typeKey in types:
+        vTypes = types[typeKey]
+        ok = True
+        for vType in vTypes:
+            if vType['name'] not in values:
+                ok = False
+                break
+        if ok:
+            primaryType = typeKey
+            break
+    if primaryType == '':
+        return None
+    return primaryType
+
+
+def TypedDataConvert(domain: dict, types: dict, values: dict):
+    EIP712DomainMap = {
+        'name': {'name': 'name', 'type': 'string'},
+        'version': {'name': 'version', 'type': 'string'},
+        'chainId': {'name': 'chainId', 'type': 'uint256'},
+        'verifyingContract': {'name': 'verifyingContract', 'type': 'address'},
+        'salt': {'name': 'salt', 'type': 'bytes32'},
+    }
+    primaryType = _getPrimaryType(types, values)
+    newValue = _fix(values.copy(), primaryType, types)
+    EIP712Domain = []
+    for domainKey in domain:
+        EIP712Domain.append(EIP712DomainMap[domainKey])
+    newTypes = types.copy()
+    newTypes['EIP712Domain'] = EIP712Domain
+    newDomain = _fix(domain, 'EIP712Domain', newTypes)
+    completedStruct = {
+        "types": newTypes,
+        "domain": newDomain,
+        "message": newValue,
+        "primaryType": primaryType,
+    }
+    return completedStruct

--- a/eth_account/messages.py
+++ b/eth_account/messages.py
@@ -27,11 +27,11 @@ from hexbytes import (
 
 from eth_account._utils.encode_typed_data.encoding_and_hashing import (
     hash_domain,
-    hash_EIP712_message,
+    hash_eip712_message,
 )
 from eth_account._utils.structured_data.hashing import (
-    hash_domain as hash_eip712_domain,
-    hash_message as hash_eip712_message,
+    hash_domain as hash_eip712_domain_legacy,
+    hash_message as hash_eip712_message_legacy,
     load_and_validate_structured_message,
 )
 from eth_account._utils.structured_data.validation import (
@@ -126,30 +126,6 @@ def encode_intended_validator(
 
 
 def encode_structured_data(
-    primitive: Union[bytes, int, Mapping] = None,
-    *,
-    hexstr: str = None,
-    text: str = None,
-) -> SignableMessage:
-    r"""
-
-    .. WARNING:: This method is deprecated. Use :meth:`encode_typed_data` instead.
-
-    Encode an EIP-712_ message.
-
-    See :meth:`encode_structured_data_legacy` for usage.
-
-    """
-    warnings.warn(
-        "`encode_structured_data` is deprecated and will be removed in a"
-        " future release. Use encode_typed_data instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return encode_structured_data_legacy(primitive, hexstr=hexstr, text=text)
-
-
-def encode_structured_data_legacy(
     primitive: Union[bytes, int, Mapping] = None,
     *,
     hexstr: str = None,
@@ -256,6 +232,13 @@ def encode_structured_data_legacy(
 
     .. _EIP-712: https://eips.ethereum.org/EIPS/eip-712
     """
+    warnings.warn(
+        "`encode_structured_data` is deprecated and will be removed in a"
+        " future release. Use encode_typed_data instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     if isinstance(primitive, Mapping):
         validate_structured_data(primitive)
         structured_data = primitive
@@ -264,8 +247,8 @@ def encode_structured_data_legacy(
         structured_data = load_and_validate_structured_message(message_string)
     return SignableMessage(
         HexBytes(b"\x01"),
-        hash_eip712_domain(structured_data),
-        hash_eip712_message(structured_data),
+        hash_eip712_domain_legacy(structured_data),
+        hash_eip712_message_legacy(structured_data),
     )
 
 
@@ -389,14 +372,13 @@ def encode_typed_data(
           types, but values larger than the type will raise ``ValueOutOfBounds``.
           e.g., an 8-byte value will be padded to fit a ``bytes16`` type, but 16-byte
           value provided for a ``bytes8`` type will raise an error.
-        - ``bool`` types will also accept ``int``s 0 and 1, ``bytes`` objects
-          ``b"\x00"`` and ``b"\x01"``, and strings such as ``"0"`` or ``"1"``, ``"OxO"``
-          or ``"0x1"``, ``"true"`` or ``"false"``, and ``True`` or ``False``.
+        - Fixed-size and dynamic ``bytes`` types will accept ``int``s. Any negative
+          values will be converted to ``0`` before being converted to ``bytes``
         - ``int`` and ``uint`` types will also accept strings. If prefixed with ``"0x"``
           , the string will be interpreted as hex. Otherwise, it will be interpreted as
           decimal.
 
-    Differences from ``signTypedData``:
+    Noteable differences from ``signTypedData``:
         - Custom types that are not alphanumeric will encode differently.
         - Custom types that are used but not defined in ``types`` will not encode.
 
@@ -455,5 +437,5 @@ def encode_typed_data(
     return SignableMessage(
         HexBytes(b"\x01"),
         hash_domain(domain_data),
-        hash_EIP712_message(message_types, message_data),
+        hash_eip712_message(message_types, message_data),
     )

--- a/newsfragments/235.deprecation.rst
+++ b/newsfragments/235.deprecation.rst
@@ -1,0 +1,1 @@
+Deprecate ``encode_structured_data`` in favor of new ``encode_typed_data``

--- a/newsfragments/235.feature.rst
+++ b/newsfragments/235.feature.rst
@@ -1,0 +1,1 @@
+Add new ``encode_typed_data`` to better handle EIP712 message signing

--- a/tests/core/test_encode_typed_data.py
+++ b/tests/core/test_encode_typed_data.py
@@ -1,12 +1,19 @@
+import re
+
+from eth_abi.exceptions import (
+    EncodingTypeError,
+    ValueOutOfBounds,
+)
 import pytest
 
-from eth_account._utils.encode_typed_data import (
-    _get_primary_type,
+from eth_account._utils.encode_typed_data.encoding_and_hashing import (
     encode_data,
     encode_field,
     encode_type,
     find_type_dependencies,
+    get_primary_type,
     hash_domain,
+    hash_EIP712_message,
     hash_struct,
     hash_type,
 )
@@ -68,7 +75,7 @@ from eth_account._utils.encode_typed_data import (
     ],
 )
 def test_get_primary_type_pass(types, expected):
-    assert _get_primary_type(types) == expected
+    assert get_primary_type(types) == expected
 
 
 @pytest.mark.parametrize(
@@ -110,7 +117,7 @@ def test_get_primary_type_pass(types, expected):
 )
 def test_get_primary_type_fail(types, expected):
     with pytest.raises(**expected):
-        _get_primary_type(types)
+        get_primary_type(types)
 
 
 @pytest.mark.parametrize(
@@ -216,6 +223,42 @@ def test_get_primary_type_fail(types, expected):
             ),
         ),
         (
+            "a_bool",
+            "bool",
+            0,
+            (
+                "bool",
+                False,
+            ),
+        ),
+        (
+            "a_bool",
+            "bool",
+            b"\x01",
+            (
+                "bool",
+                True,
+            ),
+        ),
+        (
+            "a_bool",
+            "bool",
+            "true",
+            (
+                "bool",
+                True,
+            ),
+        ),
+        (
+            "a_bool",
+            "bool",
+            "0",
+            (
+                "bool",
+                False,
+            ),
+        ),
+        (
             "an_address",
             "address",
             "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
@@ -283,6 +326,24 @@ def test_get_primary_type_fail(types, expected):
                 b"\x94}\xef\x19'\xda\xc4\x1f\x85\xfb\x87ya\x8e\x1f\x87\x96L(\x80\\\xeb\t\xe6Gv8\x0c\x19k\\\t",  # noqa: E501
             ),
         ),
+        (
+            "some_bytes",
+            "int256",
+            "0xdeadbeef",
+            (
+                "int256",
+                3735928559,
+            ),
+        ),
+        (
+            "some_string",
+            "int16",
+            "412",
+            (
+                "int16",
+                412,
+            ),
+        ),
     ),
     ids=[
         "None value for custom type",
@@ -296,12 +357,18 @@ def test_get_primary_type_fail(types, expected):
         "string[] value for string[] type",
         "string[][] value for string[][] type",
         "bool value for bool type",
+        "int value for bool type",
+        "bytes value for bool type",
+        "word str value for bool type",
+        "int str value for bool type",
         "address value for address type",
         "int16 value for int16 type",
         "uint256 value for uint256 type",
         "empty string value for string type",
         "expected value for custom type",
         "expected value for custom type array",
+        "hexstr value for int type",
+        "str value for int type",
     ],
 )
 def test_encode_field_pass(name, type_, value, expected):
@@ -328,9 +395,33 @@ def test_encode_field_pass(name, type_, value, expected):
                 "match": "missing value for field atomic_type of type address",
             },
         ),
+        (
+            "non_int_string",
+            "uint256",
+            "i am not an int",
+            {
+                "expected_exception": ValueError,
+                "match": re.escape(
+                    "invalid literal for int() with base 10: 'i am not an int'"
+                ),
+            },
+        ),
+        (
+            "non_hex_string",
+            "uint256",
+            "0xi am not an int",
+            {
+                "expected_exception": ValueError,
+                "match": re.escape(
+                    "invalid literal for int() with base 16: '0xi am not an int'"
+                ),
+            },
+        ),
     ),
     ids=[
         "None value for atomic type",
+        "string value that is not convertible to int for int type",
+        "string starting with 0x that is not convertible to int for int type",
     ],
 )
 def test_encode_field_fail(name, type_, value, expected):
@@ -621,115 +712,6 @@ def test_encode_type_fail(primary_type, types, expected):
 
 
 @pytest.mark.parametrize(
-    "type_, message, types, encode_data_expected, hash_struct_expected",
-    (
-        (
-            "Mail",
-            {
-                "from": {
-                    "name": "Cow",
-                },
-            },
-            {
-                "Person": [
-                    {"name": "name", "type": "string"},
-                ],
-                "Mail": [
-                    {"name": "from", "type": "Person"},
-                ],
-            },
-            "979fb836e7a3c69210ec4cfec014139732f26442be0f5c10c4222ccabfe6a025bfb54ec5e6bf391ea339a110356cb0fd003296b0dabe4b0b2e51d0e50c815c8a",  # noqa: E501
-            "dfa5fd27fea278587b6c6a56d8e6cf2853b6698a4244afc1f5f526f04b2b70b3",
-        ),
-        # (
-        #     "Person",
-        #     {
-        #         "Person": [
-        #             {"name": "name", "type": "string"},
-        #         ],
-        #         "Mail": [
-        #             {"name": "from", "type": "Person"},
-        #         ],
-        #     },
-        #     "Person(string name)",
-        # ),
-        # (
-        #     "Mail",
-        #     {
-        #         "Person": [
-        #             {"name": "name", "type": "string"},
-        #         ],
-        #         "Mail": [
-        #             {"name": "from", "type": "Person"},
-        #         ],
-        #     },
-        #     "Mail(Person from)Person(string name)",
-        # ),
-        # (
-        #     "Person",
-        #     {
-        #         "Person": [
-        #             {"name": "name", "type": "string"},
-        #             {"name": "friend", "type": "Person"},
-        #         ],
-        #         "Mail": [
-        #             {"name": "from", "type": "Person"},
-        #         ],
-        #     },
-        #     "Person(string name,Person friend)",
-        # ),
-        # (
-        #     "Mail",
-        #     {
-        #         "Person": [
-        #             {"name": "name", "type": "string"},
-        #             {"name": "friends", "type": "Person[]"},
-        #         ],
-        #         "Mail": [
-        #             {"name": "from", "type": "Person"},
-        #             {"name": "attachments", "type": "Attachment[]"},
-        #         ],
-        #         "Attachment": [
-        #             {"name": "from", "type": "string"},
-        #         ],
-        #     },
-        #     "Mail(Person from,Attachment[] attachments)Attachment(string from)Person(string name,Person[] friends)",  # noqa: E501
-        # ),
-        # (
-        #     "Ma il!",
-        #     {
-        #         "Person": [
-        #             {"name": "name", "type": "string"},
-        #             {"name": "friends", "type": "Person"},
-        #         ],
-        #         "Ma il!": [
-        #             {"name": "from", "type": "Person"},
-        #             {"name": "attachments", "type": "Attachment[]"},
-        #         ],
-        #         "Attachment": [
-        #             {"name": "from", "type": "string"},
-        #         ],
-        #     },
-        #     "Ma il!(Person from,Attachment[] attachments)Attachment(string from)Person(string name,Person friends)",  # noqa: E501
-        # ),
-    ),
-    ids=[
-        "primary type with one custom type dependency",
-        # "type with no dependencies",
-        # "type with one dependency",
-        # "type with recursive dependency",
-        # "type with array dependency",
-        # "type with non-alphanumeric in primary type",
-    ],
-)
-def test_encode_data_pass_and_hash_struct(
-    type_, message, types, encode_data_expected, hash_struct_expected
-):
-    assert encode_data(type_, types, message).hex() == encode_data_expected
-    assert hash_struct(type_, types, message).hex() == hash_struct_expected
-
-
-@pytest.mark.parametrize(
     "domain_data, expected",
     (
         (
@@ -778,3 +760,270 @@ def test_hash_domain_pass(domain_data, expected):
 def test_hash_domain_fail(domain_data, expected):
     with pytest.raises(**expected):
         hash_domain(domain_data)
+
+
+@pytest.mark.parametrize(
+    "type_,message, types, encode_data_expected, hash_struct_expected",
+    (
+        (
+            "Mail",
+            {
+                "from": {
+                    "name": "Cow",
+                },
+            },
+            {
+                "Person": [
+                    {"name": "name", "type": "string"},
+                ],
+                "Mail": [
+                    {"name": "from", "type": "Person"},
+                ],
+            },
+            "979fb836e7a3c69210ec4cfec014139732f26442be0f5c10c4222ccabfe6a025bfb54ec5e6bf391ea339a110356cb0fd003296b0dabe4b0b2e51d0e50c815c8a",  # noqa: E501
+            "dfa5fd27fea278587b6c6a56d8e6cf2853b6698a4244afc1f5f526f04b2b70b3",
+        ),
+        (
+            "People",
+            {
+                "who": [
+                    {
+                        "name": "Cow",
+                    },
+                    {
+                        "name": "Dan",
+                    },
+                    {
+                        "name": "Eve",
+                    },
+                ],
+            },
+            {
+                "Person": [
+                    {"name": "name", "type": "string"},
+                ],
+                "People": [
+                    {"name": "who", "type": "Person[]"},
+                ],
+            },
+            "cd6dded05d140e80a24f1b3f8ec7635be0235a2bb1ac5acc4f6a8c0e81959c1fdd333db219c66d1b097970cebde115462698f9bfe6ea7497898a67c7da923d33",  # noqa: E501
+            "978fbd13a22cb2ced753b88943583080d6e2fa20d9f5818181dd85ee26438745",
+        ),
+        (
+            "Things",
+            {
+                "what": [
+                    [
+                        {
+                            "name": "Cow",
+                        },
+                    ],
+                    [
+                        {
+                            "name": "Dan",
+                        },
+                    ],
+                    [
+                        {
+                            "name": "Eve",
+                        },
+                    ],
+                ],
+            },
+            {
+                "Stuff": [
+                    {"name": "name", "type": "string"},
+                ],
+                "Things": [
+                    {"name": "what", "type": "Stuff[][]"},
+                ],
+            },
+            "888cc41f0207f14b9f9e8dbaeb2cedc28dcd62ea4bd2d68c81ebb1416c846e63676cc832675b2d6ab9eb44e83f08c0df303bf2771036d926ed6fb385b6ee6de0",  # noqa: E501
+            "b475420217c60fe1a7ad38c925c80f5d2c58e0fbb980684e4722f810ba9235d8",
+        ),
+        (
+            "Things",
+            {
+                "what": [
+                    [
+                        {
+                            "name": "Cow",
+                        },
+                    ],
+                    [
+                        {
+                            "name": "Dan",
+                        },
+                    ],
+                    [
+                        {
+                            "name": "Eve",
+                        },
+                    ],
+                ],
+            },
+            {
+                "Stuff": [
+                    {"name": "name", "type": "string"},
+                ],
+                "Things": [
+                    {"name": "what", "type": "Stuff[3][1]"},
+                ],
+            },
+            "0e1a553943c15cc6227e8a3d2c788d3e74b25f85f30be99bfc6228e404e79fb9676cc832675b2d6ab9eb44e83f08c0df303bf2771036d926ed6fb385b6ee6de0",  # noqa: E501
+            "cdbacf00da86992e9443d46aa0206e27d670a6140155f8c505a68ba733c7e639",
+        ),
+        (
+            "Things",
+            {
+                "what": [
+                    [
+                        {
+                            "name": "Cow",
+                        },
+                    ],
+                    [
+                        {
+                            "name": "Dan",
+                        },
+                    ],
+                    [
+                        {
+                            "name": "Eve",
+                        },
+                    ],
+                ],
+            },
+            {
+                "Stuff": [
+                    {"name": "name", "type": "string"},
+                ],
+                "Things": [
+                    {"name": "what", "type": "Stuff[8][5]"},
+                ],
+            },
+            "5e38f404f170c80d6c941310101dfad8882e50828efc75c104c7675960b4cc94676cc832675b2d6ab9eb44e83f08c0df303bf2771036d926ed6fb385b6ee6de0",  # noqa: E501
+            "ed3eb2f09fad610e8805f43a34704858e1ad7f3cd12b61e712b402be370b9001",
+        ),
+        (
+            "Things",
+            {
+                "what": b"1234567890abcdef",
+            },
+            {
+                "Things": [
+                    {"name": "what", "type": "bytes16"},
+                ],
+            },
+            "b093a949c507c3814cc23da9eebb03679633e22cec8c8633c878f43b025201333132333435363738393061626364656600000000000000000000000000000000",  # noqa: E501
+            "6825950a843718a846bf289599316a041180fd20d942ae0ca6106396ff797655",
+        ),
+    ),
+    ids=[
+        "primary type with one custom type dependency",
+        "primary type with one custom type array dependency",
+        "primary type with one custom type nested array dependency",
+        "encodes when data matches defined array size",
+        "encodes when data does not match defined array size",
+        "bytes8 value for bytes16 type",
+    ],
+)
+def test_encode_data_pass_and_hash_struct_and_hash_EIP712_message(
+    type_,
+    message,
+    types,
+    encode_data_expected,
+    hash_struct_expected,
+):
+    assert encode_data(type_, types, message).hex() == encode_data_expected
+    assert hash_struct(type_, types, message).hex() == hash_struct_expected
+    assert hash_EIP712_message(types, message).hex() == hash_struct_expected
+
+
+@pytest.mark.parametrize(
+    "type_,message, types, expected_error",
+    (
+        (
+            "Things",
+            {
+                "what": b"1234567890abcdef1234567890abcdef",
+            },
+            {
+                "Things": [
+                    {"name": "what", "type": "bytes8"},
+                ],
+            },
+            {
+                "expected_exception": ValueOutOfBounds,
+                "match": "Value `b'1234567890abcdef1234567890abcdef'` of type <class "
+                "'bytes'> cannot be encoded by BytesEncoder: exceeds total "
+                "byte size for bytes8 encoding",
+            },
+        ),
+        (
+            "Things",
+            {
+                "what": 4294967295,
+            },
+            {
+                "Things": [
+                    {"name": "what", "type": "int16"},
+                ],
+            },
+            {
+                "expected_exception": ValueOutOfBounds,
+                "match": re.escape(
+                    "Value `4294967295` of type <class 'int'> cannot be encoded by SignedIntegerEncoder: Cannot be encoded in 16 bits.  Must be bounded between [-32768, 32767]."  # noqa: E501
+                ),
+            },
+        ),
+        (
+            "Things",
+            {
+                "what": "0xdeadbeef",
+            },
+            {
+                "Things": [
+                    {"name": "what", "type": "address"},
+                ],
+            },
+            {
+                "expected_exception": EncodingTypeError,
+                "match": re.escape(
+                    "Value `'0xdeadbeef'` of type <class 'str'> cannot be encoded by AddressEncoder",  # noqa: E501
+                ),
+            },
+        ),
+        (
+            "Things",
+            {
+                "what": "deadbeef",
+            },
+            {
+                "Things": [
+                    {"name": "what", "type": "int256"},
+                ],
+            },
+            {
+                "expected_exception": ValueError,
+                "match": re.escape(
+                    "invalid literal for int() with base 10: 'deadbeef",
+                ),
+            },
+        ),
+    ),
+    ids=[
+        "bytes16 value for bytes8 type",
+        "int value too large for int16 type",
+        "hexstring too short to be an address",
+        "hexstring must have 0x prefix be parsed as int",
+    ],
+)
+def test_encode_data_fail(
+    type_,
+    message,
+    types,
+    expected_error,
+):
+    with pytest.raises(**expected_error):
+        encode_data(type_, types, message)

--- a/tests/core/test_encode_typed_data.py
+++ b/tests/core/test_encode_typed_data.py
@@ -1,0 +1,780 @@
+import pytest
+
+from eth_account._utils.encode_typed_data import (
+    _get_primary_type,
+    encode_data,
+    encode_field,
+    encode_type,
+    find_type_dependencies,
+    hash_domain,
+    hash_struct,
+    hash_type,
+)
+
+
+@pytest.mark.parametrize(
+    "types, expected",
+    (
+        (
+            {
+                "Person": [
+                    {"name": "name", "type": "string"},
+                ],
+            },
+            "Person",
+        ),
+        (
+            {
+                "Person": [
+                    {"name": "name", "type": "string"},
+                ],
+                "Mail": [
+                    {"name": "from", "type": "Person"},
+                ],
+            },
+            "Mail",
+        ),
+        (
+            {
+                "Person": [
+                    {"name": "name", "type": "string"},
+                    {"name": "friend", "type": "Person"},
+                ],
+            },
+            "Person",
+        ),
+        (
+            {
+                "Person": [
+                    {"name": "name", "type": "string"},
+                    {"name": "friends", "type": "Person[]"},
+                ],
+                "Mail": [
+                    {"name": "from", "type": "Person"},
+                    {"name": "attachments", "type": "Attachment[]"},
+                ],
+                "Attachment": [
+                    {"name": "from", "type": "string"},
+                ],
+            },
+            "Mail",
+        ),
+    ),
+    ids=[
+        "primary_type with no dependencies",
+        "primary_type with one dependency",
+        "primary_type with recursive dependency",
+        "primary_type with array dependency",
+    ],
+)
+def test_get_primary_type_pass(types, expected):
+    assert _get_primary_type(types) == expected
+
+
+@pytest.mark.parametrize(
+    "types, expected",
+    (
+        (
+            {
+                "Person": [
+                    {"name": "other_person", "type": "OtherPerson"},
+                ],
+                "OtherPerson": [
+                    {"name": "Person", "type": "Person"},
+                ],
+            },
+            {
+                "expected_exception": ValueError,
+                "match": "Unable to determine primary type",
+            },
+        ),
+        (
+            {
+                "Person": [
+                    {"name": "name", "type": "string"},
+                ],
+                "Mail": [
+                    {"name": "type", "type": "string"},
+                ],
+            },
+            {
+                "expected_exception": ValueError,
+                "match": "Unable to determine primary type",
+            },
+        ),
+    ),
+    ids=[
+        "primary_type circular dependency",
+        "two primary types that do not depend on each other",
+    ],
+)
+def test_get_primary_type_fail(types, expected):
+    with pytest.raises(**expected):
+        _get_primary_type(types)
+
+
+@pytest.mark.parametrize(
+    "name, type_, value, expected",
+    (
+        (
+            "custom_type",
+            "Sample",
+            None,
+            (
+                "bytes32",
+                b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",  # noqa: E501
+            ),
+        ),
+        (
+            "name",
+            "string",
+            None,
+            (
+                "bytes32",
+                b"",
+            ),
+        ),
+        (
+            "some_bytes",
+            "bytes",
+            None,
+            (
+                "bytes32",
+                b"",
+            ),
+        ),
+        (
+            "some_bytes",
+            "bytes",
+            27,
+            (
+                "bytes32",
+                b"$\xd6\xd74\x14_\x07\x1a\xa6\xa2v?\xdd\xcaX\x10\xbd\x12#l->X\x9d*z\xdf\\\xa6\x9c\xc9\xc6",  # noqa: E501
+            ),
+        ),
+        (
+            "some_bytes",
+            "bytes",
+            "0xdeadbeef",
+            (
+                "bytes32",
+                b"\xd4\xfdN\x18\x912'06D\x9f\xc9\xe1\x11\x98\xc79\x16\x1bL\x01\x16\xa9\xa2\xdc\xcd\xfa\x1cI \x06\xf1",  # noqa: E501
+            ),
+        ),
+        (
+            "some_bytes",
+            "bytes",
+            b"\xd4\xfdN\x18\x912'06D\x9f\xc9\xe1\x11",
+            (
+                "bytes32",
+                b"p\xa6\xe6 \xc0:\xff\xea9\x0f\xad\x1a\xab\xf8\xf7\xdc\x1b\xd1\x82\x1c\xe4\xd5\xa1,m3+\x15X\x98M\xaf",  # noqa: E501
+            ),
+        ),
+        (
+            "name",
+            "string",
+            27,
+            (
+                "bytes32",
+                b"$\xd6\xd74\x14_\x07\x1a\xa6\xa2v?\xdd\xcaX\x10\xbd\x12#l->X\x9d*z\xdf\\\xa6\x9c\xc9\xc6",  # noqa: E501
+            ),
+        ),
+        (
+            "name",
+            "string",
+            "Bob",
+            (
+                "bytes32",
+                b"(\xca\xc3\x18\xa8l\x8a\nj\x91V\xc2\xdb\xa2\xc8\xc266w\xba\x05\x14\xefae\x92\xd8\x15W\xe6y\xb6",  # noqa: E501
+            ),
+        ),
+        (
+            "names",
+            "string[]",
+            "['Bob', 'Jim']",
+            (
+                "bytes32",
+                b"\xd3\xd6\xa8?%\x9eN{\xe2\xffP\xa5\xb3\xac\xa7.i\xa6\x92^\x0eq\x8c,\x12[\xeaR\xb1\xc6\x19\x1b",  # noqa: E501
+            ),
+        ),
+        (
+            "names",
+            "string[][]",
+            "[['Bob', 'Jim'],['Amy', 'Sal']]",
+            (
+                "bytes32",
+                b"$\\\x93)\x01\x91\x1a\xd7Z\x0f\x12\xd9\x93\xe6\xd9\xb1\x02\xb2\xfe\xf1\x97\xaa\xd7\x8a\xf6p\xe1\x7f\xc7\xe9v\x83",  # noqa: E501
+            ),
+        ),
+        (
+            "a_bool",
+            "bool",
+            True,
+            (
+                "bool",
+                True,
+            ),
+        ),
+        (
+            "an_address",
+            "address",
+            "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+            (
+                "address",
+                "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+            ),
+        ),
+        (
+            "an_int16",
+            "int16",
+            -25,
+            (
+                "int16",
+                -25,
+            ),
+        ),
+        (
+            "a_uint256",
+            "uint256",
+            1157920892373161954235709850086879078532699846656,
+            (
+                "uint256",
+                1157920892373161954235709850086879078532699846656,
+            ),
+        ),
+        (
+            "empty_string",
+            "string",
+            "",
+            (
+                "bytes32",
+                b"\xc5\xd2F\x01\x86\xf7#<\x92~}\xb2\xdc\xc7\x03\xc0\xe5\x00\xb6S\xca\x82';{\xfa\xd8\x04]\x85\xa4p",  # noqa: E501
+            ),
+        ),
+        (
+            "expected_sample",
+            "Sample",
+            {
+                "name": "Cow",
+            },
+            (
+                "bytes32",
+                b"\x8flivK`W\xf4my$tFGG\x9f\x99k\xbe\xb9\x8e\xcfh]\xcb\x8b\x8ak\xb9\xe5\x17\xdd",  # noqa: E501
+            ),
+        ),
+        (
+            "expected_samples",
+            "Samples",
+            {
+                "samples": [
+                    {
+                        "name": "Abe",
+                    },
+                    {
+                        "name": "Bob",
+                    },
+                    {
+                        "name": "Cow",
+                    },
+                ],
+            },
+            (
+                "bytes32",
+                b"\x94}\xef\x19'\xda\xc4\x1f\x85\xfb\x87ya\x8e\x1f\x87\x96L(\x80\\\xeb\t\xe6Gv8\x0c\x19k\\\t",  # noqa: E501
+            ),
+        ),
+    ),
+    ids=[
+        "None value for custom type",
+        "None value for string type",
+        "None value for bytes type",
+        "int value for bytes type",
+        "hexstr value for bytes type",
+        "bytes value for bytes type",
+        "int value for string type",
+        "string value for string type",
+        "string[] value for string[] type",
+        "string[][] value for string[][] type",
+        "bool value for bool type",
+        "address value for address type",
+        "int16 value for int16 type",
+        "uint256 value for uint256 type",
+        "empty string value for string type",
+        "expected value for custom type",
+        "expected value for custom type array",
+    ],
+)
+def test_encode_field_pass(name, type_, value, expected):
+    types = {
+        "Sample": [
+            {"name": "name", "type": "string"},
+        ],
+        "Samples": [
+            {"name": "samples", "type": "Sample[]"},
+        ],
+    }
+    assert encode_field(types, name, type_, value) == expected
+
+
+@pytest.mark.parametrize(
+    "name, type_, value, expected",
+    (
+        (
+            "atomic_type",
+            "address",
+            None,
+            {
+                "expected_exception": ValueError,
+                "match": "missing value for field atomic_type of type address",
+            },
+        ),
+    ),
+    ids=[
+        "None value for atomic type",
+    ],
+)
+def test_encode_field_fail(name, type_, value, expected):
+    types = {
+        "Sample": [
+            {"name": "name", "type": "string"},
+        ]
+    }
+
+    with pytest.raises(**expected):
+        encode_field(types, name, type_, value)
+
+
+@pytest.mark.parametrize(
+    "primary_type, types, expected",
+    (
+        (
+            "Person",
+            {
+                "Person": [
+                    {"name": "name", "type": "string"},
+                ],
+                "Mail": [
+                    {"name": "from", "type": "Person"},
+                ],
+            },
+            {"Person"},
+        ),
+        (
+            "Mail",
+            {
+                "Person": [
+                    {"name": "name", "type": "string"},
+                ],
+                "Mail": [
+                    {"name": "from", "type": "Person"},
+                ],
+            },
+            {"Person", "Mail"},
+        ),
+        (
+            "Person",
+            {
+                "Person": [
+                    {"name": "name", "type": "string"},
+                    {"name": "friend", "type": "Person"},
+                ],
+                "Mail": [
+                    {"name": "from", "type": "Person"},
+                ],
+            },
+            {"Person"},
+        ),
+        (
+            "Mail",
+            {
+                "Person": [
+                    {"name": "name", "type": "string"},
+                    {"name": "friends", "type": "Person[]"},
+                ],
+                "Mail": [
+                    {"name": "from", "type": "Person"},
+                    {"name": "attachments", "type": "Attachment[]"},
+                ],
+                "Attachment": [
+                    {"name": "from", "type": "string"},
+                ],
+            },
+            {"Person", "Mail", "Attachment"},
+        ),
+        (
+            "Ma il!",
+            {
+                "Person": [
+                    {"name": "name", "type": "string"},
+                    {"name": "friends", "type": "Person"},
+                ],
+                "Ma il!": [
+                    {"name": "from", "type": "Person"},
+                    {"name": "attachments", "type": "Attachment[]"},
+                ],
+                "Attachment": [
+                    {"name": "from", "type": "string"},
+                ],
+            },
+            {"Person", "Ma il!", "Attachment"},
+        ),
+    ),
+    ids=[
+        "type with no dependencies",
+        "type with one dependency",
+        "type with recursive dependency",
+        "type with array dependency",
+        "type with non-alphanumeric in primary type",
+    ],
+)
+def test_find_type_dependencies_pass(primary_type, types, expected):
+    assert find_type_dependencies(primary_type, types) == expected
+
+
+@pytest.mark.parametrize(
+    "primary_type, types, expected",
+    (
+        (
+            27,
+            {
+                27: [
+                    {"name": "name", "type": "string"},
+                ],
+                "Mail": [
+                    {"name": "from", "type": "Person"},
+                ],
+            },
+            {
+                "expected_exception": ValueError,
+                "match": "Invalid find_type_dependencies input: expected string, "
+                "got 27 of type <class 'int'>",
+            },
+        ),
+        (
+            "Person",
+            {
+                "Person": [
+                    {"name": "name", "type": "string"},
+                    {"name": "pet", "type": "Animal"},
+                ],
+                "Mail": [
+                    {"name": "from", "type": "Person"},
+                ],
+            },
+            {
+                "expected_exception": ValueError,
+                "match": "No definition of type Animal",
+            },
+        ),
+        (
+            "Mail",
+            {
+                "Person": [
+                    {"name": "name", "type": "string"},
+                    {"name": "friends", "type": "Person[]"},
+                ],
+                "Mail": [
+                    {"name": "from", "type": "Person"},
+                    {"name": "attachments", "type": "Attachment[]"},
+                ],
+            },
+            {
+                "expected_exception": ValueError,
+                "match": "No definition of type Attachment",
+            },
+        ),
+    ),
+    ids=[
+        "primary_type must be a string",
+        "custom type in dependencies but not defined in types",
+        "custom type array in dependencies but not defined in types",
+    ],
+)
+def test_find_type_dependencies_fail(primary_type, types, expected):
+    with pytest.raises(**expected):
+        find_type_dependencies(primary_type, types)
+
+
+@pytest.mark.parametrize(
+    "primary_type, types, encode_type_expected, hash_type_expected",
+    (
+        (
+            "Person",
+            {
+                "Person": [
+                    {"name": "name", "type": "string"},
+                ],
+                "Mail": [
+                    {"name": "from", "type": "Person"},
+                ],
+            },
+            "Person(string name)",
+            "fcbb73369ebb221abfdc626fdec0be9ca48ad89ef757b9a76eb7b31ddd261338",
+        ),
+        (
+            "Mail",
+            {
+                "Person": [
+                    {"name": "name", "type": "string"},
+                ],
+                "Mail": [
+                    {"name": "from", "type": "Person"},
+                ],
+            },
+            "Mail(Person from)Person(string name)",
+            "979fb836e7a3c69210ec4cfec014139732f26442be0f5c10c4222ccabfe6a025",
+        ),
+        (
+            "Person",
+            {
+                "Person": [
+                    {"name": "name", "type": "string"},
+                    {"name": "friend", "type": "Person"},
+                ],
+                "Mail": [
+                    {"name": "from", "type": "Person"},
+                ],
+            },
+            "Person(string name,Person friend)",
+            "945f8587e8daf26c14c625b054bfccb52dc48747984b7925c0901efca7186e14",
+        ),
+        (
+            "Mail",
+            {
+                "Person": [
+                    {"name": "name", "type": "string"},
+                    {"name": "friends", "type": "Person[]"},
+                ],
+                "Mail": [
+                    {"name": "from", "type": "Person"},
+                    {"name": "attachments", "type": "Attachment[]"},
+                ],
+                "Attachment": [
+                    {"name": "from", "type": "string"},
+                ],
+            },
+            "Mail(Person from,Attachment[] attachments)Attachment(string from)Person(string name,Person[] friends)",  # noqa: E501
+            "0c555dd4d869769a9f68c39860155342ea7e75a215669bc44efca1b4544735e5",
+        ),
+        (
+            "Ma il!",
+            {
+                "Person": [
+                    {"name": "name", "type": "string"},
+                    {"name": "friends", "type": "Person"},
+                ],
+                "Ma il!": [
+                    {"name": "from", "type": "Person"},
+                    {"name": "attachments", "type": "Attachment[]"},
+                ],
+                "Attachment": [
+                    {"name": "from", "type": "string"},
+                ],
+            },
+            "Ma il!(Person from,Attachment[] attachments)Attachment(string from)Person(string name,Person friends)",  # noqa: E501
+            "099b05cabe783f37d88d94e349693aca4fc9ae40c51e5d2640ff040768e5b2ad",
+        ),
+    ),
+    ids=[
+        "type with no dependencies",
+        "type with one dependency",
+        "type with recursive dependency",
+        "type with array dependency",
+        "type with non-alphanumeric in primary type",
+    ],
+)
+def test_encode_type_pass_and_hash_type(
+    primary_type, types, encode_type_expected, hash_type_expected
+):
+    assert encode_type(primary_type, types) == encode_type_expected
+    assert hash_type(primary_type, types).hex() == hash_type_expected
+
+
+@pytest.mark.parametrize(
+    "primary_type, types, expected",
+    (
+        (
+            "Mail",
+            {
+                "Person": [
+                    {"name": "name", "type": "string"},
+                    {"name": "friends", "type": "Person[]"},
+                ],
+                "Mail": [
+                    {"name": "from", "type": "Person"},
+                    {"name": "attachments", "type": "Attachment[]"},
+                ],
+            },
+            {
+                "expected_exception": ValueError,
+                "match": "No definition of type Attachment",
+            },
+        ),
+    ),
+    ids=[
+        "custom type array in dependencies but not defined in types",
+    ],
+)
+def test_encode_type_fail(primary_type, types, expected):
+    with pytest.raises(**expected):
+        encode_type(primary_type, types)
+
+
+@pytest.mark.parametrize(
+    "type_, message, types, encode_data_expected, hash_struct_expected",
+    (
+        (
+            "Mail",
+            {
+                "from": {
+                    "name": "Cow",
+                },
+            },
+            {
+                "Person": [
+                    {"name": "name", "type": "string"},
+                ],
+                "Mail": [
+                    {"name": "from", "type": "Person"},
+                ],
+            },
+            "979fb836e7a3c69210ec4cfec014139732f26442be0f5c10c4222ccabfe6a025bfb54ec5e6bf391ea339a110356cb0fd003296b0dabe4b0b2e51d0e50c815c8a",  # noqa: E501
+            "dfa5fd27fea278587b6c6a56d8e6cf2853b6698a4244afc1f5f526f04b2b70b3",
+        ),
+        # (
+        #     "Person",
+        #     {
+        #         "Person": [
+        #             {"name": "name", "type": "string"},
+        #         ],
+        #         "Mail": [
+        #             {"name": "from", "type": "Person"},
+        #         ],
+        #     },
+        #     "Person(string name)",
+        # ),
+        # (
+        #     "Mail",
+        #     {
+        #         "Person": [
+        #             {"name": "name", "type": "string"},
+        #         ],
+        #         "Mail": [
+        #             {"name": "from", "type": "Person"},
+        #         ],
+        #     },
+        #     "Mail(Person from)Person(string name)",
+        # ),
+        # (
+        #     "Person",
+        #     {
+        #         "Person": [
+        #             {"name": "name", "type": "string"},
+        #             {"name": "friend", "type": "Person"},
+        #         ],
+        #         "Mail": [
+        #             {"name": "from", "type": "Person"},
+        #         ],
+        #     },
+        #     "Person(string name,Person friend)",
+        # ),
+        # (
+        #     "Mail",
+        #     {
+        #         "Person": [
+        #             {"name": "name", "type": "string"},
+        #             {"name": "friends", "type": "Person[]"},
+        #         ],
+        #         "Mail": [
+        #             {"name": "from", "type": "Person"},
+        #             {"name": "attachments", "type": "Attachment[]"},
+        #         ],
+        #         "Attachment": [
+        #             {"name": "from", "type": "string"},
+        #         ],
+        #     },
+        #     "Mail(Person from,Attachment[] attachments)Attachment(string from)Person(string name,Person[] friends)",  # noqa: E501
+        # ),
+        # (
+        #     "Ma il!",
+        #     {
+        #         "Person": [
+        #             {"name": "name", "type": "string"},
+        #             {"name": "friends", "type": "Person"},
+        #         ],
+        #         "Ma il!": [
+        #             {"name": "from", "type": "Person"},
+        #             {"name": "attachments", "type": "Attachment[]"},
+        #         ],
+        #         "Attachment": [
+        #             {"name": "from", "type": "string"},
+        #         ],
+        #     },
+        #     "Ma il!(Person from,Attachment[] attachments)Attachment(string from)Person(string name,Person friends)",  # noqa: E501
+        # ),
+    ),
+    ids=[
+        "primary type with one custom type dependency",
+        # "type with no dependencies",
+        # "type with one dependency",
+        # "type with recursive dependency",
+        # "type with array dependency",
+        # "type with non-alphanumeric in primary type",
+    ],
+)
+def test_encode_data_pass_and_hash_struct(
+    type_, message, types, encode_data_expected, hash_struct_expected
+):
+    assert encode_data(type_, types, message).hex() == encode_data_expected
+    assert hash_struct(type_, types, message).hex() == hash_struct_expected
+
+
+@pytest.mark.parametrize(
+    "domain_data, expected",
+    (
+        (
+            {
+                "name": "Ether Mail",
+                "version": "1",
+                "chainId": 1,
+                "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+            },
+            "f2cee375fa42b42143804025fc449deafd50cc031ca257e0b194a650a912090f",
+        ),
+        (
+            {},
+            "6192106f129ce05c9075d319c1fa6ea9b3ae37cbd0c1ef92e2be7137bb07baa1",
+        ),
+    ),
+    ids=[
+        "EIP712 example domain data",
+        "empty domain data",
+    ],
+)
+def test_hash_domain_pass(domain_data, expected):
+    assert hash_domain(domain_data).hex() == expected
+
+
+@pytest.mark.parametrize(
+    "domain_data, expected",
+    (
+        (
+            {
+                "name": "Ether Mail",
+                "classification": "1",
+                "chainId": 1,
+                "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+            },
+            {
+                "expected_exception": ValueError,
+                "match": "Invalid domain key: classification",
+            },
+        ),
+    ),
+    ids=[
+        "key in domain_data not in EIP712 domain fields",
+    ],
+)
+def test_hash_domain_fail(domain_data, expected):
+    with pytest.raises(**expected):
+        hash_domain(domain_data)

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ profile=black
 max-line-length=88
 exclude=venv*,.tox,docs,build
 extend-ignore=E203,W503
+per-file-ignores = __init__.py:F401
 
 [testenv]
 commands=


### PR DESCRIPTION
### What was wrong?

EIP712 message signing could be more user-friendly. eth-account's `encode_structured_data` has a different interface and encodes edge cases differently than users of Metamask and ethers.js have come to expect.

Closes #221

### How was it fixed?

Using Metamask's `eth-sig-util` and ethers.js as a model, I built out new mechanics for encoding EIP712 typed data.

Notable differences:
 - No attention paid to array dimensions
 - `None` values are allowed for custom, `string`, and `bytes` types.

Allowing `encode_typed_data` to be called with a single dict in the manner of `encode_structured_data` will be added in a separate PR.

### Todo:
- [x] rename `encode_structured_data` to indicate legacy and add deprecation notice
- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-account/assets/5199899/73848935-9438-496c-aa90-b34d98335b5d)