### PR TITLE
update ethers integration testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ integration: &integration
           python -m pip install tox
     - run:
         name: install dependencies (node)
-        command: sudo -E bash tests/integration/ethers-cli/setup_node_v18.sh && sudo apt-get install -y nodejs
+        command: sudo -E bash tests/integration/ethers-cli/setup_node_v20.sh && sudo apt-get install -y nodejs
     - run:
         name: Build ethers-cli
         command: cd tests/integration/ethers-cli && sudo npm install && sudo npm install -g . && cd ../../../

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To run the integration test cases, you need to install node and the custom cli t
 
 ```sh
 apt-get install -y nodejs  # As sudo
-./tests/integration/ethers-cli/setup_node_v18.sh  # As sudo
+./tests/integration/ethers-cli/setup_node_v20.sh  # As sudo
 cd tests/integration/ethers-cli
 npm install -g .  # As sudo
 ```

--- a/newsfragments/236.internal.rst
+++ b/newsfragments/236.internal.rst
@@ -1,0 +1,1 @@
+Bump version for node and ethers.js in integration tests, update ethers usage to match

--- a/tests/integration/ethers-cli/index.js
+++ b/tests/integration/ethers-cli/index.js
@@ -60,8 +60,9 @@ switch(options.language) {
 // If specified, use the given path, else default to Ethereum
 const path = options.path ? options.path : "m/44'/60'/0'/0/0";
 
-const account = ethers.Wallet.fromMnemonic(
+const account = ethers.HDNodeWallet.fromPhrase(
     options.mnemonic.join(" "),
+    undefined, // an optional password arg that we don't use
     path,
     wordlist,
 );

--- a/tests/integration/ethers-cli/package-lock.json
+++ b/tests/integration/ethers-cli/package-lock.json
@@ -1,777 +1,269 @@
 {
   "name": "ethers-cli",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@ethersproject/abi": {
-      "version": "5.0.0-beta.145",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.0-beta.145.tgz",
-      "integrity": "sha512-buO1aiUe408qo8guMzwvzezUVKmQyhM21sbNaG8XrktrnxTNLvRghN1NYbtQi8Ov0ZT+P93VPz1whKu1Y2s2Xg==",
-      "requires": {
-        "@ethersproject/address": ">=5.0.0-beta.128",
-        "@ethersproject/bignumber": ">=5.0.0-beta.130",
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "@ethersproject/constants": ">=5.0.0-beta.128",
-        "@ethersproject/hash": ">=5.0.0-beta.128",
-        "@ethersproject/keccak256": ">=5.0.0-beta.127",
-        "@ethersproject/logger": ">=5.0.0-beta.129",
-        "@ethersproject/properties": ">=5.0.0-beta.131",
-        "@ethersproject/strings": ">=5.0.0-beta.130"
-      }
-    },
-    "@ethersproject/abstract-provider": {
-      "version": "5.0.0-beta.138",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.0-beta.138.tgz",
-      "integrity": "sha512-bIEBUMm62TxTF+zHOUHPfMQLf3gvN5cVR1Gyv5/LVuDz3UESgFTBHBpFLHPlW2/RLHDo7K0jx16a38vs6/r2gQ==",
-      "requires": {
-        "@ethersproject/bignumber": ">=5.0.0-beta.130",
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "@ethersproject/logger": ">=5.0.0-beta.129",
-        "@ethersproject/networks": ">=5.0.0-beta.129",
-        "@ethersproject/properties": ">=5.0.0-beta.131",
-        "@ethersproject/transactions": ">=5.0.0-beta.128",
-        "@ethersproject/web": ">=5.0.0-beta.129"
-      }
-    },
-    "@ethersproject/abstract-signer": {
-      "version": "5.0.0-beta.140",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.0-beta.140.tgz",
-      "integrity": "sha512-fROSxYPhtXqxK1y6/mJMpCUcjfUzCSuqNfACcPy2pwoOHMz1hsqS7m7HOEXy0HGAsQPw4fVuo4fywfA+Q62kmQ==",
-      "requires": {
-        "@ethersproject/abstract-provider": ">=5.0.0-beta.131",
-        "@ethersproject/bignumber": ">=5.0.0-beta.130",
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "@ethersproject/logger": ">=5.0.0-beta.129",
-        "@ethersproject/properties": ">=5.0.0-beta.131"
-      }
-    },
-    "@ethersproject/address": {
-      "version": "5.0.0-beta.134",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.0-beta.134.tgz",
-      "integrity": "sha512-FHhUVJTUIg2pXvOOhIt8sB1cQbcwrzZKzf9CPV7JM1auli20nGoYhyMFYGK7u++GXzTMJduIkU1OwlIBupewDw==",
-      "requires": {
-        "@ethersproject/bignumber": ">=5.0.0-beta.130",
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "@ethersproject/keccak256": ">=5.0.0-beta.127",
-        "@ethersproject/logger": ">=5.0.0-beta.129",
-        "@ethersproject/rlp": ">=5.0.0-beta.126",
-        "bn.js": "^4.4.0"
-      }
-    },
-    "@ethersproject/base64": {
-      "version": "5.0.0-beta.131",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.0-beta.131.tgz",
-      "integrity": "sha512-pjgZZyDlGpSBkbuO87hnmVrOa92znIt5EIGBW1Mly5Nby8PU4YVwK3WoRP2vGd7hViNVLPCgfbmhh6LQhWK1sg==",
-      "requires": {
-        "@ethersproject/bytes": ">=5.0.0-beta.129"
-      }
-    },
-    "@ethersproject/basex": {
-      "version": "5.0.0-beta.132",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.0-beta.132.tgz",
-      "integrity": "sha512-BlTGjIW5O03Tl3cVrBWPYnSnhEdz7h3sAely82xDZPutUw9PyPy/PF7IN19iVNgv5ZKQlaDmQZ6M2OGzVOuIPw==",
-      "requires": {
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "@ethersproject/properties": ">=5.0.0-beta.131"
-      }
-    },
-    "@ethersproject/bignumber": {
-      "version": "5.0.0-beta.135",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.0-beta.135.tgz",
-      "integrity": "sha512-7Tw2NgHzK7o+70bwyoaIZCbRycz+saWNU0sLOYnis3qYXwYsdTL+Rm0PMGA2v4jyHJt7BPS2pxGww+akVXbX+w==",
-      "requires": {
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "@ethersproject/logger": ">=5.0.0-beta.129",
-        "@ethersproject/properties": ">=5.0.0-beta.131",
-        "bn.js": "^4.4.0"
-      }
-    },
-    "@ethersproject/bytes": {
-      "version": "5.0.0-beta.136",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.0-beta.136.tgz",
-      "integrity": "sha512-yoi5Ul16ScMHVNsf+oCDGaAnj+rtXxITcneXPeDl8h0rk1VNIqb1WKKvooD5WtM0oAglyauuDahHIF+4+5G/Sg==",
-      "requires": {
-        "@ethersproject/logger": ">=5.0.0-beta.129"
-      }
-    },
-    "@ethersproject/constants": {
-      "version": "5.0.0-beta.133",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.0-beta.133.tgz",
-      "integrity": "sha512-VCTpk3AF00mlWQw1vg+fI6qCo0qO5EVWK574t4HNBKW6X748jc9UJPryKUz9JgZ64ZQupyLM92wHilsG/YTpNQ==",
-      "requires": {
-        "@ethersproject/bignumber": ">=5.0.0-beta.130"
-      }
-    },
-    "@ethersproject/contracts": {
-      "version": "5.0.0-beta.143",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.0-beta.143.tgz",
-      "integrity": "sha512-xjWNlnbhfAkWxBW1ICi6l/O9iplf6GW8IlN57DddERCuzJnj3t2g3PinVTacH27ySqApnWF2FbFQIf0BRYp5hQ==",
-      "requires": {
-        "@ethersproject/abi": ">=5.0.0-beta.137",
-        "@ethersproject/abstract-provider": ">=5.0.0-beta.131",
-        "@ethersproject/abstract-signer": ">=5.0.0-beta.132",
-        "@ethersproject/address": ">=5.0.0-beta.128",
-        "@ethersproject/bignumber": ">=5.0.0-beta.130",
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "@ethersproject/constants": ">=5.0.0-beta.128",
-        "@ethersproject/logger": ">=5.0.0-beta.129",
-        "@ethersproject/properties": ">=5.0.0-beta.131",
-        "@ethersproject/transactions": ">=5.0.0-beta.128"
-      }
-    },
-    "@ethersproject/hash": {
-      "version": "5.0.0-beta.133",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.0-beta.133.tgz",
-      "integrity": "sha512-tfF11QxFlJCy92rMtUZ0kImchWhlYXkN5Gj5cYfTcCdWEUKwNq1LljDnlrjV2JabO6s5enb8uiUj4RBTo2+Rgw==",
-      "requires": {
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "@ethersproject/keccak256": ">=5.0.0-beta.127",
-        "@ethersproject/logger": ">=5.0.0-beta.129",
-        "@ethersproject/strings": ">=5.0.0-beta.130"
-      }
-    },
-    "@ethersproject/hdnode": {
-      "version": "5.0.0-beta.137",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.0-beta.137.tgz",
-      "integrity": "sha512-TDe57vm/tndbaSKi/NRgC0uAp4uVr60LurTAw+u6mG5ihZg9mlYgr15GxOXWTRiJfa3V3kQD8VsTpzlNMYHViw==",
-      "requires": {
-        "@ethersproject/abstract-signer": ">=5.0.0-beta.132",
-        "@ethersproject/basex": ">=5.0.0-beta.127",
-        "@ethersproject/bignumber": ">=5.0.0-beta.130",
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "@ethersproject/logger": ">=5.0.0-beta.129",
-        "@ethersproject/pbkdf2": ">=5.0.0-beta.127",
-        "@ethersproject/properties": ">=5.0.0-beta.131",
-        "@ethersproject/sha2": ">=5.0.0-beta.129",
-        "@ethersproject/signing-key": ">=5.0.0-beta.129",
-        "@ethersproject/strings": ">=5.0.0-beta.130",
-        "@ethersproject/transactions": ">=5.0.0-beta.128",
-        "@ethersproject/wordlists": ">=5.0.0-beta.128"
-      }
-    },
-    "@ethersproject/json-wallets": {
-      "version": "5.0.0-beta.136",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.0-beta.136.tgz",
-      "integrity": "sha512-hO10rNY+m39lTjP6TWb91+rGx1flsde/LP5Ajx/mXeBwx2pLm8dWAv7h7XdymCeUvFgwVdDx2jAskm+9u1AN1Q==",
-      "requires": {
-        "@ethersproject/abstract-signer": ">=5.0.0-beta.132",
-        "@ethersproject/address": ">=5.0.0-beta.128",
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "@ethersproject/hdnode": ">=5.0.0-beta.130",
-        "@ethersproject/keccak256": ">=5.0.0-beta.127",
-        "@ethersproject/logger": ">=5.0.0-beta.129",
-        "@ethersproject/pbkdf2": ">=5.0.0-beta.127",
-        "@ethersproject/properties": ">=5.0.0-beta.131",
-        "@ethersproject/random": ">=5.0.0-beta.128",
-        "@ethersproject/strings": ">=5.0.0-beta.130",
-        "@ethersproject/transactions": ">=5.0.0-beta.128",
-        "aes-js": "3.0.0",
-        "scrypt-js": "3.0.0",
-        "uuid": "2.0.1"
-      }
-    },
-    "@ethersproject/keccak256": {
-      "version": "5.0.0-beta.131",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.0-beta.131.tgz",
-      "integrity": "sha512-KQnqMwGV0IMOjAr/UTFO8DuLrmN1uaMvcV3zh9hiXhh3rCuY+WXdeUh49w1VQ94kBKmaP0qfGb7z4SdhUWUHjw==",
-      "requires": {
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "js-sha3": "0.5.7"
-      }
-    },
-    "@ethersproject/logger": {
-      "version": "5.0.0-beta.134",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.0-beta.134.tgz",
-      "integrity": "sha512-0nqZqf12/dCNfUhmpSvJweW6xQk9ixqgo/Fy3bVMbGKbuzezZtKPphGB5ibspvimWrVK7U6jLBTKHgRQKjU8Lg=="
-    },
-    "@ethersproject/networks": {
-      "version": "5.0.0-beta.135",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.0-beta.135.tgz",
-      "integrity": "sha512-9wesbAlsewNe0dU8B/lhK449GZml+08Opjf6nFpcV8BwWlYnPLs7EnOsK3GpMM0KDPZlksVYltyq+X1B7YxOcA==",
-      "requires": {
-        "@ethersproject/logger": ">=5.0.0-beta.129"
-      }
-    },
-    "@ethersproject/pbkdf2": {
-      "version": "5.0.0-beta.133",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.0-beta.133.tgz",
-      "integrity": "sha512-dOOiJSuPyQWoTexbXugVQY75vZbsediR+d1UhEfnPkKavAuks/o5mRyKYSO/EXY0qwWH01xCUEjg0RWGm93kCQ==",
-      "requires": {
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "@ethersproject/sha2": ">=5.0.0-beta.129"
-      }
-    },
-    "@ethersproject/properties": {
-      "version": "5.0.0-beta.137",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.0-beta.137.tgz",
-      "integrity": "sha512-AcvoVmV0aXixa7SxaPj237OAIEXl/UMJf4vl2yFNzWjf77mMyZaZoKLLOh2zes++mLeQ3EJEIebSWFm06L5NuA==",
-      "requires": {
-        "@ethersproject/logger": ">=5.0.0-beta.129"
-      }
-    },
-    "@ethersproject/providers": {
-      "version": "5.0.0-beta.153",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.0-beta.153.tgz",
-      "integrity": "sha512-FJ/dNM5fj25m1XAEJzdC1B6GM9On3eRn/Vls6cUcSBWTOfKsTRf0uRSkBq1kNbPdx3lF0zQT4xIVmCCklA+DaQ==",
-      "requires": {
-        "@ethersproject/abstract-provider": ">=5.0.0-beta.131",
-        "@ethersproject/abstract-signer": ">=5.0.0-beta.132",
-        "@ethersproject/address": ">=5.0.0-beta.128",
-        "@ethersproject/bignumber": ">=5.0.0-beta.130",
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "@ethersproject/constants": ">=5.0.0-beta.128",
-        "@ethersproject/hash": ">=5.0.0-beta.128",
-        "@ethersproject/logger": ">=5.0.0-beta.129",
-        "@ethersproject/networks": ">=5.0.0-beta.129",
-        "@ethersproject/properties": ">=5.0.0-beta.131",
-        "@ethersproject/random": ">=5.0.0-beta.128",
-        "@ethersproject/rlp": ">=5.0.0-beta.126",
-        "@ethersproject/strings": ">=5.0.0-beta.130",
-        "@ethersproject/transactions": ">=5.0.0-beta.128",
-        "@ethersproject/web": ">=5.0.0-beta.129"
-      }
-    },
-    "@ethersproject/random": {
-      "version": "5.0.0-beta.133",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.0-beta.133.tgz",
-      "integrity": "sha512-walmaJK9MWy02I0SAHmv5Dg8His0Vn4x/ehqlu081z5gpm0WRo9H+3tlhaHQzAI0aK6B3mRV0bsG+PvWRh41Jg==",
-      "requires": {
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "@ethersproject/logger": ">=5.0.0-beta.129"
-      }
-    },
-    "@ethersproject/rlp": {
-      "version": "5.0.0-beta.131",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.0-beta.131.tgz",
-      "integrity": "sha512-sUJUGbywlnuk2frkSWzWiGenTrwOnrKQaNKJqjCGmK35x0WIzcR4/1gC6jWa0hpWJT6Seq6J6SCT5CS+ZWCFNw==",
-      "requires": {
-        "@ethersproject/bytes": ">=5.0.0-beta.129"
-      }
-    },
-    "@ethersproject/sha2": {
-      "version": "5.0.0-beta.134",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.0-beta.134.tgz",
-      "integrity": "sha512-N/4c+erhRzfGSgOa8vSDUsorL/k/3NNubR5mwrthufMyvmfAsZDizkMPnRqC4HLy39jSmD35c8FFAEC8ebTd0w==",
-      "requires": {
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "@ethersproject/logger": ">=5.0.0-beta.129",
-        "hash.js": "1.1.3"
-      },
+  "packages": {
+    "": {
+      "name": "ethers-cli",
+      "version": "1.0.0",
+      "license": "ISC",
       "dependencies": {
-        "hash.js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.0"
-          }
-        }
-      }
-    },
-    "@ethersproject/signing-key": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
-      "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
-      "requires": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "bn.js": "^5.2.1",
-        "elliptic": "6.5.4",
-        "hash.js": "1.1.7"
+        "ethers": "^6.7.1",
+        "yargs": "^17.7.2"
       },
-      "dependencies": {
-        "@ethersproject/bytes": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
-          "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
-          "requires": {
-            "@ethersproject/logger": "^5.7.0"
-          }
-        },
-        "@ethersproject/logger": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
-          "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig=="
-        },
-        "@ethersproject/properties": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
-          "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
-          "requires": {
-            "@ethersproject/logger": "^5.7.0"
-          }
-        },
-        "bn.js": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+      "bin": {
+        "ethers-cli": "index.js"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.2.tgz",
+      "integrity": "sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg=="
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
         }
-      }
+      ]
     },
-    "@ethersproject/solidity": {
-      "version": "5.0.0-beta.131",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.0-beta.131.tgz",
-      "integrity": "sha512-i5vuj2CXGMkVPo08bmElC2cvhjRDNRZZ8nzvx2WCi75Zh42xD0XNV77E9ZLYgS0WoZSiAi/F71nXSBnM7FAqJg==",
-      "requires": {
-        "@ethersproject/bignumber": ">=5.0.0-beta.130",
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "@ethersproject/keccak256": ">=5.0.0-beta.127",
-        "@ethersproject/sha2": ">=5.0.0-beta.129",
-        "@ethersproject/strings": ">=5.0.0-beta.130"
-      }
-    },
-    "@ethersproject/strings": {
-      "version": "5.0.0-beta.136",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.0-beta.136.tgz",
-      "integrity": "sha512-Hb9RvTrgGcOavHvtQZz+AuijB79BO3g1cfF2MeMfCU9ID4j3mbZv/olzDMS2pK9r4aERJpAS94AmlWzCgoY2LQ==",
-      "requires": {
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "@ethersproject/constants": ">=5.0.0-beta.128",
-        "@ethersproject/logger": ">=5.0.0-beta.129"
-      }
-    },
-    "@ethersproject/transactions": {
-      "version": "5.0.0-beta.134",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.0-beta.134.tgz",
-      "integrity": "sha512-06VxNv6UHds153Ey3WJ2YDPReNkwmIm8fyuJOXRZ6IoYh5ns5CfR4fkmHSBtw7+/KIVjmRoMQZ4Yg/tcGmzz0A==",
-      "requires": {
-        "@ethersproject/address": ">=5.0.0-beta.128",
-        "@ethersproject/bignumber": ">=5.0.0-beta.130",
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "@ethersproject/constants": ">=5.0.0-beta.128",
-        "@ethersproject/keccak256": ">=5.0.0-beta.127",
-        "@ethersproject/logger": ">=5.0.0-beta.129",
-        "@ethersproject/properties": ">=5.0.0-beta.131",
-        "@ethersproject/rlp": ">=5.0.0-beta.126",
-        "@ethersproject/signing-key": ">=5.0.0-beta.129"
-      }
-    },
-    "@ethersproject/units": {
-      "version": "5.0.0-beta.132",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.0-beta.132.tgz",
-      "integrity": "sha512-3GZDup1uTydvqaP5wpwoRF36irp6kx/gd3buPG+aoGWLPCoPjyk76OiGoxNQKfEaynOdZ7zG2lM8WevlBDJ57g==",
-      "requires": {
-        "@ethersproject/bignumber": ">=5.0.0-beta.130",
-        "@ethersproject/constants": ">=5.0.0-beta.128",
-        "@ethersproject/logger": ">=5.0.0-beta.129"
-      }
-    },
-    "@ethersproject/wallet": {
-      "version": "5.0.0-beta.137",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.0-beta.137.tgz",
-      "integrity": "sha512-L5Ms3Rdq5LYpTHXRqZ17rdIKlbVlRUbncHtp1bMa+W7VGZJoQEWSLXtqN+q0u6Lx+w2Cg1sHvXqL+i66TRhDkw==",
-      "requires": {
-        "@ethersproject/abstract-provider": ">=5.0.0-beta.131",
-        "@ethersproject/abstract-signer": ">=5.0.0-beta.132",
-        "@ethersproject/address": ">=5.0.0-beta.128",
-        "@ethersproject/bignumber": ">=5.0.0-beta.130",
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "@ethersproject/hash": ">=5.0.0-beta.128",
-        "@ethersproject/hdnode": ">=5.0.0-beta.130",
-        "@ethersproject/json-wallets": ">=5.0.0-beta.129",
-        "@ethersproject/keccak256": ">=5.0.0-beta.127",
-        "@ethersproject/logger": ">=5.0.0-beta.129",
-        "@ethersproject/properties": ">=5.0.0-beta.131",
-        "@ethersproject/random": ">=5.0.0-beta.128",
-        "@ethersproject/signing-key": ">=5.0.0-beta.129",
-        "@ethersproject/transactions": ">=5.0.0-beta.128",
-        "@ethersproject/wordlists": ">=5.0.0-beta.128"
-      }
-    },
-    "@ethersproject/web": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
-      "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
-      "requires": {
-        "@ethersproject/base64": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
-      },
-      "dependencies": {
-        "@ethersproject/base64": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
-          "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
-          "requires": {
-            "@ethersproject/bytes": "^5.7.0"
-          }
-        },
-        "@ethersproject/bignumber": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
-          "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
-          "requires": {
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "bn.js": "^5.2.1"
-          }
-        },
-        "@ethersproject/bytes": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
-          "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
-          "requires": {
-            "@ethersproject/logger": "^5.7.0"
-          }
-        },
-        "@ethersproject/constants": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
-          "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.7.0"
-          }
-        },
-        "@ethersproject/logger": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
-          "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig=="
-        },
-        "@ethersproject/properties": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
-          "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
-          "requires": {
-            "@ethersproject/logger": "^5.7.0"
-          }
-        },
-        "@ethersproject/strings": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
-          "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
-          "requires": {
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/constants": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0"
-          }
-        },
-        "bn.js": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+    "node_modules/@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
         }
-      }
+      ]
     },
-    "@ethersproject/wordlists": {
-      "version": "5.0.0-beta.135",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.0-beta.135.tgz",
-      "integrity": "sha512-hGwIme0in4cJrhdumTJVc1OLEa7S/oxALMOION4C+31yKFdWfX00dOXi6aqokWkGaUQXvmHz4r9/GhfqzoB2Qg==",
-      "requires": {
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "@ethersproject/hash": ">=5.0.0-beta.128",
-        "@ethersproject/logger": ">=5.0.0-beta.129",
-        "@ethersproject/properties": ">=5.0.0-beta.131",
-        "@ethersproject/strings": ">=5.0.0-beta.130"
-      }
+    "node_modules/@types/node": {
+      "version": "18.15.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
     },
-    "aes-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
     },
-    "ansi-regex": {
+    "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "ansi-styles": {
+    "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "requires": {
+      "dependencies": {
         "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "bn.js": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-    },
-    "brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
-    },
-    "camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-    },
-    "cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "requires": {
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
-    "color-convert": {
+    "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "requires": {
+      "dependencies": {
         "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
       }
     },
-    "color-name": {
+    "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
-    },
-    "elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-      "requires": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        }
-      }
-    },
-    "emoji-regex": {
+    "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
-    "ethers": {
-      "version": "5.0.0-beta.173",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.0-beta.173.tgz",
-      "integrity": "sha512-wAj6vYXL6Kgm6baLCZRJukMo/4DmHe7lMd0xLZhtc7PJbgJwiTGwjfpGxLSoj0EWFh69o0TXVQ0PDNgvfWjDyw==",
-      "requires": {
-        "@ethersproject/abi": ">=5.0.0-beta.137",
-        "@ethersproject/abstract-provider": ">=5.0.0-beta.131",
-        "@ethersproject/abstract-signer": ">=5.0.0-beta.132",
-        "@ethersproject/address": ">=5.0.0-beta.128",
-        "@ethersproject/base64": ">=5.0.0-beta.126",
-        "@ethersproject/bignumber": ">=5.0.0-beta.130",
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "@ethersproject/constants": ">=5.0.0-beta.128",
-        "@ethersproject/contracts": ">=5.0.0-beta.137",
-        "@ethersproject/hash": ">=5.0.0-beta.128",
-        "@ethersproject/hdnode": ">=5.0.0-beta.130",
-        "@ethersproject/json-wallets": ">=5.0.0-beta.129",
-        "@ethersproject/keccak256": ">=5.0.0-beta.127",
-        "@ethersproject/logger": ">=5.0.0-beta.129",
-        "@ethersproject/networks": ">=5.0.0-beta.129",
-        "@ethersproject/pbkdf2": ">=5.0.0-beta.127",
-        "@ethersproject/properties": ">=5.0.0-beta.131",
-        "@ethersproject/providers": ">=5.0.0-beta.141",
-        "@ethersproject/random": ">=5.0.0-beta.128",
-        "@ethersproject/rlp": ">=5.0.0-beta.126",
-        "@ethersproject/sha2": ">=5.0.0-beta.129",
-        "@ethersproject/signing-key": ">=5.0.0-beta.129",
-        "@ethersproject/solidity": ">=5.0.0-beta.126",
-        "@ethersproject/strings": ">=5.0.0-beta.130",
-        "@ethersproject/transactions": ">=5.0.0-beta.128",
-        "@ethersproject/units": ">=5.0.0-beta.127",
-        "@ethersproject/wallet": ">=5.0.0-beta.130",
-        "@ethersproject/web": ">=5.0.0-beta.129",
-        "@ethersproject/wordlists": ">=5.0.0-beta.128"
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "engines": {
+        "node": ">=6"
       }
     },
-    "find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "requires": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
+    "node_modules/ethers": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.7.1.tgz",
+      "integrity": "sha512-qX5kxIFMfg1i+epfgb0xF4WM7IqapIIu50pOJ17aebkxxa4BacW5jFrQRmCJpDEg2ZK2oNtR5QjrQ1WDBF29dA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.9.2",
+        "@noble/hashes": "1.1.2",
+        "@noble/secp256k1": "1.7.1",
+        "@types/node": "18.15.13",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "get-caller-file": {
+    "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
-    },
-    "hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "is-fullwidth-code-point": {
+    "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-    },
-    "js-sha3": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-      "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-    },
-    "locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "requires": {
-        "p-locate": "^4.1.0"
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
       }
     },
-    "minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
-    },
-    "minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
-    },
-    "p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "requires": {
-        "p-try": "^2.0.0"
-      }
-    },
-    "p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "requires": {
-        "p-limit": "^2.2.0"
-      }
-    },
-    "p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-    },
-    "path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-    },
-    "require-directory": {
+    "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
-    },
-    "scrypt-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.0.tgz",
-      "integrity": "sha512-7CC7aufwukEvqdmllR0ny0QaSg0+S22xKXrXz3ZahaV6J+fgD2YAtrjtImuoDWog17/Ty9Q4HBmnXEXJ3JkfQA=="
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
-    },
-    "string-width": {
+    "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "requires": {
+      "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "strip-ansi": {
+    "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "requires": {
+      "dependencies": {
         "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "uuid": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-      "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+    "node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
-    "which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q=="
-    },
-    "wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "requires": {
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+    "node_modules/ws": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
-    "yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-      "requires": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
-    "yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
       }
     }
   }

--- a/tests/integration/ethers-cli/package.json
+++ b/tests/integration/ethers-cli/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ethers": "^5.0.0-beta.173 ",
-    "yargs": "^15.1.0"
+    "ethers": "^6.7.1",
+    "yargs": "^17.7.2"
   }
 }

--- a/tests/integration/ethers-cli/setup_node_v20.sh
+++ b/tests/integration/ethers-cli/setup_node_v20.sh
@@ -3,14 +3,14 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js 18.x repo onto a
+# Script to install the NodeSource Node.js 20.x repo onto a
 # Debian or Ubuntu system.
 #
 # Run as root or insert `sudo -E` before `bash`:
 #
-# curl -sL https://deb.nodesource.com/setup_18.x | bash -
+# curl -sL https://deb.nodesource.com/setup_20.x | bash -
 #   or
-# wget -qO- https://deb.nodesource.com/setup_18.x | bash -
+# wget -qO- https://deb.nodesource.com/setup_20.x | bash -
 #
 # CONTRIBUTIONS TO THIS SCRIPT
 #
@@ -21,9 +21,9 @@
 
 
 export DEBIAN_FRONTEND=noninteractive
-SCRSUFFIX="_18.x"
-NODENAME="Node.js 18.x"
-NODEREPO="node_18.x"
+SCRSUFFIX="_20.x"
+NODENAME="Node.js 20.x"
+NODEREPO="node_20.x"
 NODEPKG="nodejs"
 
 print_status() {
@@ -113,7 +113,8 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://deb.nodesource.com/setup_14.x — Node.js 14 \"Fermium\"${normal}
    * ${green}https://deb.nodesource.com/setup_16.x — Node.js 16 \"Gallium\"${normal}
    * ${green}https://deb.nodesource.com/setup_18.x — Node.js 18 LTS \"Hydrogen\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_19.x — Node.js 19 \"Nineteen\"${normal} (current)
+   * ${green}https://deb.nodesource.com/setup_19.x — Node.js 19 \"Nineteen\"${normal}
+   * ${green}https://deb.nodesource.com/setup_20.x — Node.js 20 \"Iron\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -143,7 +144,8 @@ This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used t
    * ${green}https://deb.nodesource.com/setup_14.x — Node.js 14 \"Fermium\"${normal}
    * ${green}https://deb.nodesource.com/setup_16.x — Node.js 16 \"Gallium\"${normal}
    * ${green}https://deb.nodesource.com/setup_18.x — Node.js 18 LTS \"Hydrogen\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_19.x — Node.js 19 \"Nineteen\"${normal} (current)
+   * ${green}https://deb.nodesource.com/setup_19.x — Node.js 19 \"Nineteen\"${normal}
+   * ${green}https://deb.nodesource.com/setup_20.x — Node.js 20 \"Iron\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -238,10 +240,12 @@ check_alt "Devuan"         "ascii"           "Debian"        "stretch"
 check_alt "Devuan"         "beowulf"         "Debian"        "buster"
 check_alt "Devuan"         "chimaera"        "Debian"        "bullseye"
 check_alt "Devuan"         "ceres"           "Debian"        "sid"
+check_alt "Devuan"         "daedalus"        "Debian"        "bookworm"
 check_alt "Deepin"         "panda"           "Debian"        "sid"
 check_alt "Deepin"         "unstable"        "Debian"        "sid"
 check_alt "Deepin"         "stable"          "Debian"        "buster"
 check_alt "Deepin"         "apricot"         "Debian"        "buster"
+check_alt "Deepin"         "beige"           "Debian"        "bookworm"
 check_alt "elementaryOS"   "luna"            "Ubuntu"        "precise"
 check_alt "elementaryOS"   "freya"           "Ubuntu"        "trusty"
 check_alt "elementaryOS"   "loki"            "Ubuntu"        "xenial"
@@ -249,6 +253,7 @@ check_alt "elementaryOS"   "juno"            "Ubuntu"        "bionic"
 check_alt "elementaryOS"   "hera"            "Ubuntu"        "bionic"
 check_alt "elementaryOS"   "odin"            "Ubuntu"        "focal"
 check_alt "elementaryOS"   "jolnir"          "Ubuntu"        "focal"
+check_alt "elementaryOS"   "horus"           "Ubuntu"        "jammy"
 check_alt "Kali"           "sana"            "Debian"        "jessie"
 check_alt "Kali"           "kali-rolling"    "Debian"        "bullseye"
 check_alt "Linux Mint"     "maya"            "Ubuntu"        "precise"


### PR DESCRIPTION
### What was wrong?

Ethers mnemonic/hd wallet testing was using an old version of ethers. More javascript testing will be added with incoming typed-data signing, so upgrading this now in preparation.

### How was it fixed?

Upgraded `ethers` version to the latest, and bumped `node.js` version from 18 to 20.

### Todo:
- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-account/assets/5199899/7f61005e-40ba-43c0-a6ae-6c17fad4c1e2)