### PR TITLE
add build.os to rtd settings

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,13 @@
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
+sphinx:
+   configuration: docs/conf.py
+
 python:
   install:
     - method: pip

--- a/newsfragments/237.internal.rst
+++ b/newsfragments/237.internal.rst
@@ -1,0 +1,1 @@
+Add ``build.os`` to readthedocs settings


### PR DESCRIPTION
### What was wrong?

ReadTheDocs will soon start requiring a `build.os` to be specified

### How was it fixed?

Added to readthedocs.yml

### Todo:
- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-account/assets/5199899/e7d6d9f2-f33e-4630-ac80-d56855ddb660)