### PR TITLE
Add ability to call encode_typed_data with a single dict argument

### DIFF
--- a/eth_account/_utils/encode_typed_data/encoding_and_hashing.py
+++ b/eth_account/_utils/encode_typed_data/encoding_and_hashing.py
@@ -63,8 +63,24 @@ def encode_field(
         raise ValueError(f"Missing value for field `{name}` of type `{type_}`")
 
     elif is_array_type(type_):
-        type_ = parse_parent_array_type(type_)
-        type_value_pairs = [encode_field(types, name, type_, item) for item in value]
+        # handle array type with non-array value
+        if not isinstance(value, list):
+            raise ValueError(
+                f"Invalid value for field `{name}` of type `{type_}`: "
+                f"expected array, got `{value}` of type `{type(value)}`"
+            )
+
+        parsed_type = parse_parent_array_type(type_)
+        type_value_pairs = [
+            encode_field(types, name, parsed_type, item) for item in value
+        ]
+        if not type_value_pairs:
+            # the keccak hash of `encode((), ())`
+            return (
+                "bytes32",
+                b"\xc5\xd2F\x01\x86\xf7#<\x92~}\xb2\xdc\xc7\x03\xc0\xe5\x00\xb6S\xca\x82';{\xfa\xd8\x04]\x85\xa4p",  # noqa: E501
+            )
+
         data_types, data_hashes = zip(*type_value_pairs)
         return ("bytes32", keccak(encode(data_types, data_hashes)))
 

--- a/eth_account/messages.py
+++ b/eth_account/messages.py
@@ -26,6 +26,7 @@ from hexbytes import (
 )
 
 from eth_account._utils.encode_typed_data.encoding_and_hashing import (
+    get_primary_type,
     hash_domain,
     hash_eip712_message,
 )
@@ -346,26 +347,34 @@ def defunct_hash_message(
 
 
 def encode_typed_data(
-    domain_data: Dict[Any, Any],
-    message_types: Dict[Any, Any],
-    message_data: Dict,
+    domain_data: Dict[str, Any] = None,
+    message_types: Dict[str, Any] = None,
+    message_data: Dict[str, Any] = None,
+    full_message: Dict[str, Any] = None,
 ) -> SignableMessage:
     r"""
     Encode an EIP-712_ message in a manner compatible with other implementations
     in use, such as the Metamask and Ethers ``signTypedData`` functions.
 
-    Supply the message as exactly three arguments:
+    You may supply the information to be encoded in one of two ways:
+
+    As exactly three arguments:
 
         - ``domain_data``, a dict of the EIP-712 domain data
-        - ``message_types``, a dict of custom types
+        - ``message_types``, a dict of custom types (do not include a ``EIP712Domain``
+          key)
         - ``message_data``, a dict of the data to be signed
+
+    Or as a single argument:
+
+        - ``full_message``, a dict containing the following keys:
+            - ``types``, a dict of custom types (may include a ``EIP712Domain`` key)
+            - ``primaryType``, (optional) a string of the primary type of the message
+            - ``domain``, a dict of the EIP-712 domain data
+            - ``message``, a dict of the data to be signed
 
     .. WARNING:: Note that this code has not gone through an external audit, and
         the test cases are incomplete.
-
-    Usage Notes:
-        - ``message_types`` should not include the ``EIP712Domain`` key. It will be
-            derived from ``domain_data``.
 
     Type Coercion:
         - For fixed-size bytes types, smaller values will be padded to fit in larger
@@ -385,15 +394,17 @@ def encode_typed_data(
     :param domain_data: EIP712 domain data
     :param message_types: custom types used by the `value` data
     :param message_data: data to be signed
+    :param full_message: a dict containing all data and types
     :returns: a ``SignableMessage``, an encoded message ready to be signed
 
 
     .. doctest:: python
 
-        >>> # an example of basic usage
+        >>> # examples of basic usage
         >>> import json
         >>> from eth_account import Account
         >>> from eth_account.messages import encode_typed_data
+        >>> # 3-argument usage
 
         >>> # all domain properties are optional
         >>> domain_data = {
@@ -432,10 +443,112 @@ def encode_typed_data(
         >>> signed_msg = Account.sign_message(signable_msg, key)
         >>> signed_msg.messageHash
         HexBytes('0xc5bb16ccc59ae9a3ad1cb8343d4e3351f057c994a97656e1aff8c134e56f7530')
+
+        >>> # 1-argument usage
+
+        >>> # all domain properties are optional
+        >>> full_message = {
+        ...     "types": {
+        ...         "EIP712Domain": [
+        ...             {"name": "name", "type": "string"},
+        ...             {"name": "version", "type": "string"},
+        ...             {"name": "chainId", "type": "uint256"},
+        ...             {"name": "verifyingContract", "type": "address"},
+        ...             {"name": "salt", "type": "bytes32"},
+        ...         ],
+        ...         "Person": [
+        ...             {"name": "name", "type": "string"},
+        ...             {"name": "wallet", "type": "address"},
+        ...         ],
+        ...         "Mail": [
+        ...             {"name": "from", "type": "Person"},
+        ...             {"name": "to", "type": "Person"},
+        ...             {"name": "contents", "type": "string"},
+        ...         ],
+        ...     },
+        ...     "primaryType": "Mail",
+        ...     "domain": {
+        ...         "name": "Ether Mail",
+        ...         "version": "1",
+        ...         "chainId": 1,
+        ...         "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+        ...         "salt": b"decafbeef"
+        ...     },
+        ...     "message": {
+        ...         "from": {
+        ...             "name": "Cow",
+        ...             "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+        ...         },
+        ...         "to": {
+        ...             "name": "Bob",
+        ...             "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+        ...         },
+        ...         "contents": "Hello, Bob!",
+        ...     },
+        ... }
+        >>> signable_msg_2 = encode_typed_data(full_message=full_message)
+        >>> signed_msg_2 = Account.sign_message(signable_msg_2, key)
+        >>> signed_msg_2.messageHash
+        HexBytes('0xc5bb16ccc59ae9a3ad1cb8343d4e3351f057c994a97656e1aff8c134e56f7530')
+        >>> signed_msg_2 == signed_msg
+        True
     .. _EIP-712: https://eips.ethereum.org/EIPS/eip-712
     """
+    if full_message is not None:
+        if (
+            domain_data is not None
+            or message_types is not None
+            or message_data is not None
+        ):
+            raise ValueError(
+                "You may supply either `full_message` as a single argument or "
+                "`domain_data`, `message_types`, and `message_data` as three arguments,"
+                " but not both."
+            )
+
+        full_message_types = full_message["types"].copy()
+        full_message_domain = full_message["domain"].copy()
+
+        # If EIP712Domain types were provided, check that they match the domain data
+        if "EIP712Domain" in full_message_types:
+            domain_data_keys = list(full_message_domain.keys())
+            domain_types_keys = [
+                field["name"] for field in full_message_types["EIP712Domain"]
+            ]
+
+            if set(domain_data_keys) != (set(domain_types_keys)):
+                raise ValidationError(
+                    "The fields provided in `domain` do not match the fields provided"
+                    " in `types.EIP712Domain`. The fields provided in `domain` were"
+                    f" `{domain_data_keys}`, but the fields provided in "
+                    f"`types.EIP712Domain` were `{domain_types_keys}`."
+                )
+
+        full_message_types.pop("EIP712Domain", None)
+
+        # If primaryType was provided, check that it matches the derived primaryType
+        if "primaryType" in full_message:
+            derived_primary_type = get_primary_type(full_message_types)
+            provided_primary_type = full_message["primaryType"]
+            if derived_primary_type != provided_primary_type:
+                raise ValidationError(
+                    "The provided `primaryType` does not match the derived "
+                    "`primaryType`. The provided `primaryType` was "
+                    f"`{provided_primary_type}`, but the derived `primaryType` was "
+                    f"`{derived_primary_type}`."
+                )
+
+        parsed_domain_data = full_message_domain
+        parsed_message_types = full_message_types
+        parsed_message_data = full_message["message"]
+
+    else:
+        parsed_domain_data = domain_data
+        parsed_message_types = message_types
+        parsed_message_data = message_data
+
     return SignableMessage(
         HexBytes(b"\x01"),
-        hash_domain(domain_data),
-        hash_eip712_message(message_types, message_data),
+        hash_domain(parsed_domain_data),
+        hash_eip712_message(parsed_message_types, parsed_message_data),
     )

--- a/newsfragments/238.feature.rst
+++ b/newsfragments/238.feature.rst
@@ -1,0 +1,1 @@
+Added option to call ``encode_typed_data`` with a single dict arg in addition to the existing 3-dict style

--- a/tests/core/test_encode_typed_data/test_encode_typed_data_full_messages.py
+++ b/tests/core/test_encode_typed_data/test_encode_typed_data_full_messages.py
@@ -1,0 +1,58 @@
+import json
+import os
+
+from eth_utils import (
+    ValidationError,
+)
+import pytest
+
+from eth_account.messages import (
+    encode_typed_data,
+)
+
+
+def load_file(file_name):
+    with open(os.path.join("tests/eip712_messages", file_name), "r") as f:
+        return json.load(f)
+
+
+valid = load_file("valid.json")
+invalid = load_file("invalid.json")
+one_arg_invalid = load_file("one_arg_invalid.json")
+
+
+def convert_to_3_arg(message):
+    domain_data = message["domain"]
+    message_types = message["types"]
+    message_types.pop("EIP712Domain", None)
+    message_data = message["message"]
+    return domain_data, message_types, message_data
+
+
+@pytest.mark.parametrize("test_cases", (valid, invalid, one_arg_invalid))
+def test_there_are_no_duplicate_test_cases(test_cases):
+    string_test_cases = [json.dumps(msg, sort_keys=True) for msg in test_cases.values()]
+    assert len(string_test_cases) == len(set(string_test_cases))
+
+
+@pytest.mark.parametrize("message", valid)
+def test_valid_messages(message):
+    assert encode_typed_data(full_message=valid[message]) == encode_typed_data(
+        *convert_to_3_arg(valid[message])
+    )
+
+
+@pytest.mark.parametrize("message", invalid)
+def test_invalid_messages(message):
+    with pytest.raises(ValueError):
+        encode_typed_data(full_message=invalid[message])
+
+    with pytest.raises(ValueError):
+        encode_typed_data(*convert_to_3_arg(invalid[message]))
+
+
+@pytest.mark.parametrize("message", one_arg_invalid)
+def test_messages_that_are_only_invalid_for_one_arg_encoding(message):
+    with pytest.raises(ValidationError):
+        encode_typed_data(full_message=one_arg_invalid[message])
+    encode_typed_data(*convert_to_3_arg(one_arg_invalid[message]))

--- a/tests/core/test_encode_typed_data/test_encode_typed_data_internals.py
+++ b/tests/core/test_encode_typed_data/test_encode_typed_data_internals.py
@@ -225,19 +225,19 @@ def test_get_primary_type_fail(types, expected):
         (
             "names",
             "string[]",
-            "['Bob', 'Jim']",
+            ["Bob", "Jim"],
             (
                 "bytes32",
-                b"\xd3\xd6\xa8?%\x9eN{\xe2\xffP\xa5\xb3\xac\xa7.i\xa6\x92^\x0eq\x8c,\x12[\xeaR\xb1\xc6\x19\x1b",  # noqa: E501
+                b"@u,V\x9a<\x1a0\x1d\xf0b\xda\xc4\x98\x10/\xfb\xcf\x06\xba\x96pDC/\n\xb5\xe9\x9dB\t!",  # noqa: E501
             ),
         ),
         (
             "names",
             "string[][]",
-            "[['Bob', 'Jim'],['Amy', 'Sal']]",
+            [["Bob", "Jim"], ["Amy", "Sal"]],
             (
                 "bytes32",
-                b"$\\\x93)\x01\x91\x1a\xd7Z\x0f\x12\xd9\x93\xe6\xd9\xb1\x02\xb2\xfe\xf1\x97\xaa\xd7\x8a\xf6p\xe1\x7f\xc7\xe9v\x83",  # noqa: E501
+                b"\xcd\x13is\x93\xf4\xf8^\xa7\x9bi\xec\x8cE\xfc\xfe\xab\xcc9p\x0c\xa8\xecR$\xbc]\xc6[\x10-1",  # noqa: E501
             ),
         ),
         (
@@ -452,6 +452,24 @@ def test_get_primary_type_fail(types, expected):
                 412,
             ),
         ),
+        (
+            "a_string_array",
+            "string[]",
+            [],
+            (
+                "bytes32",
+                b"\xc5\xd2F\x01\x86\xf7#<\x92~}\xb2\xdc\xc7\x03\xc0\xe5\x00\xb6S\xca\x82';{\xfa\xd8\x04]\x85\xa4p",  # noqa: E501
+            ),
+        ),
+        (
+            "custom_type",
+            "Samples",
+            {"name": "bob", "samples": []},
+            (
+                "bytes32",
+                b"(^\x89e\x13 \xa6\x16\xdf\r3\x1bOC\ngW\xb6\\\xb7\x1fn\x10\x8eh\xdc\x06\xa5\xd5\\\xc2\xb3",  # noqa: E501
+            ),
+        ),
     ),
     ids=[
         "None value for custom type",
@@ -489,6 +507,8 @@ def test_get_primary_type_fail(types, expected):
         "str value for int16 type",
         "int value for int type",
         "int value for uint type",
+        "empty array value for string[] type",
+        "empty array value for custom[] type",
     ],
 )
 def test_encode_field_pass(name, type_, value, expected):
@@ -537,11 +557,35 @@ def test_encode_field_pass(name, type_, value, expected):
                 ),
             },
         ),
+        (
+            "a_string",
+            "string",
+            [],
+            {
+                "expected_exception": TypeError,
+                "match": re.escape(
+                    "Arguments passed as hexstr or text must be of text type. Instead, value was: '[]'"  # noqa: E501
+                ),
+            },
+        ),
+        (
+            "missing_inner_array",
+            "string[][]",
+            ["a", "b", "c"],
+            {
+                "expected_exception": ValueError,
+                "match": re.escape(
+                    "Invalid value for field `missing_inner_array` of type `string[]`: expected array, got `a` of type `<class 'str'>`"  # noqa: E501
+                ),
+            },
+        ),
     ),
     ids=[
         "None value for atomic type",
         "string value that is not convertible to int for int type",
         "string starting with 0x that is not convertible to int for int type",
+        "empty array value for string type",
+        "string[] value for string[][] type",
     ],
 )
 def test_encode_field_fail(name, type_, value, expected):

--- a/tests/eip712_messages/invalid.json
+++ b/tests/eip712_messages/invalid.json
@@ -1,0 +1,547 @@
+{
+    "invalid_data_field_name_does_not_match_type_field_name": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "hello wallet",
+                    "type": "address"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "from",
+                    "type": "Person"
+                },
+                {
+                    "name": "to",
+                    "type": "Person"
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                }
+            ]
+        },
+        "primaryType": "Mail",
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "from": {
+                "name": "Cow",
+                "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            },
+            "to": {
+                "name": "Bob",
+                "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+            },
+            "contents": "Hello, Bob!"
+        }
+    },
+    "invalid_char_string_invalid_for_int_type": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "balance",
+                    "type": "uint256"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "from",
+                    "type": "Person"
+                },
+                {
+                    "name": "to",
+                    "type": "Person"
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                }
+            ]
+        },
+        "primaryType": "Mail",
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "from": {
+                "name": "Cow",
+                "balance": 1234
+            },
+            "to": {
+                "name": "Bob",
+                "balance": "how do you do?"
+            },
+            "contents": "Hello Bob!"
+        }
+    },
+    "invalid_single_array_value_for_nested_array_type": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "wallet",
+                    "type": "address"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "from",
+                    "type": "person"
+                },
+                {
+                    "name": "to",
+                    "type": "person[2][][4]"
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                }
+            ]
+        },
+        "primaryType": "Mail",
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "from": {
+                "name": "Cow",
+                "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            },
+            "to": [
+                {
+                    "name": "Bob",
+                    "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+                }
+            ],
+            "contents": "Hello, Bob!"
+        }
+    },
+    "invalid_bad_uint_field_type_in_types_passed_an_int": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "balance",
+                    "type": "uint25689"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "from",
+                    "type": "Person"
+                },
+                {
+                    "name": "to",
+                    "type": "Person"
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                }
+            ]
+        },
+        "primaryType": "Mail",
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "from": {
+                "name": "Cow",
+                "balance": 123
+            },
+            "to": {
+                "name": "Bob",
+                "balance": 1234
+            },
+            "contents": "Hello Bob!"
+        }
+    },
+    "invalid_undefined_field_type_in_types": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "wallet",
+                    "type": "address"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "from",
+                    "type": "Hello Person"
+                },
+                {
+                    "name": "to",
+                    "type": "Person"
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                }
+            ]
+        },
+        "primaryType": "Mail",
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "from": {
+                "name": "Cow",
+                "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            },
+            "to": {
+                "name": "Bob",
+                "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+            },
+            "contents": "Hello, Bob!"
+        }
+    },
+    "invalid_bad_uint_field_type_in_types_passed_a_string": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "balance",
+                    "type": "uint25689"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "from",
+                    "type": "Person"
+                },
+                {
+                    "name": "to",
+                    "type": "Person"
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                }
+            ]
+        },
+        "primaryType": "Mail",
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "from": {
+                "name": "Cow",
+                "balance": "123"
+            },
+            "to": {
+                "name": "Bob",
+                "balance": "0x1234"
+            },
+            "contents": "Hello Bob!"
+        }
+    },
+    "invalid_custom_typed_used_but_not_defined": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "wallet",
+                    "type": "address"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "from",
+                    "type": "Person"
+                },
+                {
+                    "name": "to",
+                    "type": "Person"
+                },
+                {
+                    "name": "cc",
+                    "type": "Person[]"
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                },
+                {
+                    "name": "attachments",
+                    "type": "Attachment[]"
+                }
+            ]
+        },
+        "primaryType": "Mail",
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "from": {
+                "name": "Cow",
+                "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            },
+            "to": {
+                "name": "Bob",
+                "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+            },
+            "cc": [
+                {
+                    "name": "Alice",
+                    "wallet": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                },
+                {
+                    "name": "Dot",
+                    "wallet": "0xdddddddddddddddddddddddddddddddddddddddd"
+                }
+            ],
+            "contents": "Hello, Bob!",
+            "attachments": []
+        }
+    },
+    "invalid_string_array_value_for_nested_string_array_type": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "wallet",
+                    "type": "address"
+                },
+                {
+                    "name": "nicknames",
+                    "type": "string[][]"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "from",
+                    "type": "Person"
+                },
+                {
+                    "name": "to",
+                    "type": "Person"
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                }
+            ]
+        },
+        "primaryType": "Mail",
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "from": {
+                "name": "Cow",
+                "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826",
+                "nicknames": [
+                    "bovine",
+                    "Bessie",
+                    "Daisy"
+                ]
+            },
+            "to": {
+                "name": "Bob",
+                "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+                "nicknames": [
+                    []
+                ]
+            },
+            "contents": "Hello, Bob!"
+        }
+    }
+}

--- a/tests/eip712_messages/one_arg_invalid.json
+++ b/tests/eip712_messages/one_arg_invalid.json
@@ -1,0 +1,263 @@
+{
+    "one_arg_invalid_domain_value_not_in_domain_types": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "wallet",
+                    "type": "address"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "from",
+                    "type": "Person"
+                },
+                {
+                    "name": "to",
+                    "type": "Person"
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                }
+            ]
+        },
+        "primaryType": "Mail",
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+            "salt": "0x1234567890123456789012345678901234567890123456789012345678901234"
+        },
+        "message": {
+            "from": {
+                "name": "Cow",
+                "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            },
+            "to": {
+                "name": "Bob",
+                "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+            },
+            "contents": "Hello, Bob!"
+        }
+    },
+    "one_arg_invalid_domain_type_not_in_domain_values": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                },
+                {
+                    "name": "salt",
+                    "type": "bytes32"
+                }
+            ],
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "wallet",
+                    "type": "address"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "from",
+                    "type": "Person"
+                },
+                {
+                    "name": "to",
+                    "type": "Person"
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                }
+            ]
+        },
+        "primaryType": "Mail",
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "from": {
+                "name": "Cow",
+                "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            },
+            "to": {
+                "name": "Bob",
+                "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+            },
+            "contents": "Hello, Bob!"
+        }
+    },
+    "one_arg_invalid_non_primary_type_for_primary_type": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "wallet",
+                    "type": "address"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "from",
+                    "type": "Person"
+                },
+                {
+                    "name": "to",
+                    "type": "Person"
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                }
+            ]
+        },
+        "primaryType": "Person",
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "from": {
+                "name": "Cow",
+                "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            },
+            "to": {
+                "name": "Bob",
+                "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+            },
+            "contents": "Hello, Bob!"
+        }
+    },
+    "one_arg_invalid_undefined_type_for_primary_type": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "wallet",
+                    "type": "address"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "from",
+                    "type": "Person"
+                },
+                {
+                    "name": "to",
+                    "type": "Person"
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                }
+            ]
+        },
+        "primaryType": "Horse",
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "from": {
+                "name": "Cow",
+                "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            },
+            "to": {
+                "name": "Bob",
+                "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+            },
+            "contents": "Hello, Bob!"
+        }
+    }
+}

--- a/tests/eip712_messages/valid.json
+++ b/tests/eip712_messages/valid.json
@@ -1,0 +1,1289 @@
+{
+    "valid_space_in_custom_type": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "Per son": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "wallet",
+                    "type": "address"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "from",
+                    "type": "Per son"
+                },
+                {
+                    "name": "to",
+                    "type": "Per son"
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                }
+            ]
+        },
+        "primaryType": "Mail",
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "from": {
+                "name": "Cow",
+                "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            },
+            "to": {
+                "name": "Bob",
+                "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+            },
+            "contents": "Hello, Bob!"
+        }
+    },
+    "valid_int_value_for_string_type": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "wallet",
+                    "type": "address"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "from",
+                    "type": "Person"
+                },
+                {
+                    "name": "to",
+                    "type": "Person"
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                }
+            ]
+        },
+        "primaryType": "Mail",
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "from": {
+                "name": "Cow",
+                "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            },
+            "to": {
+                "name": "Bob",
+                "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+            },
+            "contents": 12345
+        }
+    },
+    "valid_space_in_custom_type_fieldname": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "wallet",
+                    "type": "address"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "from",
+                    "type": "Person"
+                },
+                {
+                    "name": "to",
+                    "type": "Person"
+                },
+                {
+                    "name": "cont ents",
+                    "type": "string"
+                }
+            ]
+        },
+        "primaryType": "Mail",
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "from": {
+                "name": "Cow",
+                "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            },
+            "to": {
+                "name": "Bob",
+                "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+            },
+            "cont ents": "Hello, Bob!"
+        }
+    },
+    "valid_multi_no_fixed_len_array": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "Company": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "id",
+                    "type": "uint256"
+                }
+            ],
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "company",
+                    "type": "Company"
+                },
+                {
+                    "name": "aliases",
+                    "type": "string[]"
+                },
+                {
+                    "name": "wallet",
+                    "type": "address"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "ids",
+                    "type": "uint256[]"
+                },
+                {
+                    "name": "from",
+                    "type": "Person"
+                },
+                {
+                    "name": "to",
+                    "type": "Person"
+                },
+                {
+                    "name": "cc",
+                    "type": "Person[]"
+                },
+                {
+                    "name": "bcc",
+                    "type": "Person[][]"
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                },
+                {
+                    "name": "tags",
+                    "type": "string[][][]"
+                }
+            ]
+        },
+        "primaryType": "Mail",
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "ids": [
+                2,
+                3,
+                5,
+                7,
+                11,
+                13,
+                17,
+                19
+            ],
+            "from": {
+                "name": "Cow",
+                "company": {
+                    "name": "farm",
+                    "id": 1
+                },
+                "aliases": [
+                    "Vaca",
+                    "\u041a\u043e\u0440\u043e\u0432\u0430",
+                    "Koe"
+                ],
+                "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            },
+            "to": {
+                "name": "Bob",
+                "company": {
+                    "name": "fishery",
+                    "id": 2
+                },
+                "aliases": [
+                    "Bib",
+                    "Bab"
+                ],
+                "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+            },
+            "cc": [
+                {
+                    "name": "Alice",
+                    "company": {
+                        "name": "theme-park",
+                        "id": 3
+                    },
+                    "aliases": [],
+                    "wallet": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                },
+                {
+                    "name": "Dot",
+                    "company": {
+                        "name": "ice-cream",
+                        "id": 4
+                    },
+                    "aliases": [
+                        "Dash"
+                    ],
+                    "wallet": "0xdddddddddddddddddddddddddddddddddddddddd"
+                }
+            ],
+            "bcc": [
+                [
+                    {
+                        "name": "Earnest",
+                        "company": {
+                            "name": "eatery",
+                            "id": 5
+                        },
+                        "aliases": [],
+                        "wallet": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+                    },
+                    {
+                        "name": "Felicia",
+                        "company": {
+                            "name": "fine dining",
+                            "id": 6
+                        },
+                        "aliases": [
+                            "Fiona"
+                        ],
+                        "wallet": "0xffffffffffffffffffffffffffffffffffffffff"
+                    }
+                ]
+            ],
+            "contents": "Hello, Bob!",
+            "tags": [
+                [
+                    [
+                        "ab",
+                        "cd"
+                    ],
+                    [
+                        "ef",
+                        "gh"
+                    ],
+                    [
+                        "ij",
+                        "kl"
+                    ],
+                    [
+                        "mn",
+                        "op"
+                    ]
+                ],
+                [
+                    [
+                        "ch",
+                        "de"
+                    ],
+                    [
+                        "gb",
+                        "cn"
+                    ],
+                    [
+                        "mx",
+                        "cz"
+                    ],
+                    [
+                        "jp",
+                        "co"
+                    ]
+                ]
+            ]
+        }
+    },
+    "valid_eip712_example": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "wallet",
+                    "type": "address"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "from",
+                    "type": "Person"
+                },
+                {
+                    "name": "to",
+                    "type": "Person"
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                }
+            ]
+        },
+        "primaryType": "Mail",
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "from": {
+                "name": "Cow",
+                "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            },
+            "to": {
+                "name": "Bob",
+                "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+            },
+            "contents": "Hello, Bob!"
+        }
+    },
+    "valid_issue_201_with_array": {
+        "domain": {
+            "chainId": 1,
+            "name": "Test",
+            "verifyingContract": "0x0000000000000000000000000000000000000000",
+            "version": "1"
+        },
+        "message": {
+            "name": [
+                "0xAb8483F64d9C6d1EcF9b849Ae677dD3315835cb2",
+                "0xAb8483F64d9C6d1EcF9b849Ae677dD3315835cb2"
+            ]
+        },
+        "primaryType": "Person",
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "address[]"
+                }
+            ]
+        }
+    },
+    "valid_missing_eip712_type": {
+        "types": {
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "wallet",
+                    "type": "address"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "from",
+                    "type": "Person"
+                },
+                {
+                    "name": "to",
+                    "type": "Person"
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                }
+            ]
+        },
+        "primaryType": "Mail",
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "from": {
+                "name": "Cow",
+                "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            },
+            "to": {
+                "name": "Bob",
+                "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+            },
+            "contents": "Hello, Bob!"
+        }
+    },
+    "valid_eip712_example_with_array": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "wallet",
+                    "type": "address"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "from",
+                    "type": "Person"
+                },
+                {
+                    "name": "to",
+                    "type": "Person"
+                },
+                {
+                    "name": "cc",
+                    "type": "Person[]"
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                }
+            ]
+        },
+        "primaryType": "Mail",
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "from": {
+                "name": "Cow",
+                "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            },
+            "to": {
+                "name": "Bob",
+                "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+            },
+            "cc": [
+                {
+                    "name": "Alice",
+                    "wallet": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                },
+                {
+                    "name": "Dot",
+                    "wallet": "0xdddddddddddddddddddddddddddddddddddddddd"
+                }
+            ],
+            "contents": "Hello, Bob!"
+        }
+    },
+    "valid_null_value_for_custom_type": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "wallet",
+                    "type": "address"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "from",
+                    "type": "Person"
+                },
+                {
+                    "name": "to",
+                    "type": "Person"
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                }
+            ]
+        },
+        "primaryType": "Mail",
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "from": {
+                "name": "Cow",
+                "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            },
+            "to": null,
+            "contents": "Hello, Bob!"
+        }
+    },
+    "valid_missing_primary_type_key": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "wallet",
+                    "type": "address"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "from",
+                    "type": "Person"
+                },
+                {
+                    "name": "to",
+                    "type": "Person"
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                }
+            ]
+        },
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "from": {
+                "name": "Cow",
+                "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            },
+            "to": {
+                "name": "Bob",
+                "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+            },
+            "contents": "Hello, Bob!"
+        }
+    },
+    "valid_eip712_example_addresses_not_checksummed": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "wallet",
+                    "type": "address"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "from",
+                    "type": "Person"
+                },
+                {
+                    "name": "to",
+                    "type": "Person"
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                }
+            ]
+        },
+        "primaryType": "Mail",
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xcccccccccccccccccccccccccccccccccccccccc"
+        },
+        "message": {
+            "from": {
+                "name": "Cow",
+                "wallet": "0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826"
+            },
+            "to": {
+                "name": "Bob",
+                "wallet": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            },
+            "contents": "Hello, Bob!"
+        }
+    },
+    "valid_primary_type_is_empty_string": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "wallet",
+                    "type": "address"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "from",
+                    "type": ""
+                },
+                {
+                    "name": "to",
+                    "type": ""
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                }
+            ]
+        },
+        "primaryType": "Mail",
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "from": {
+                "name": "Cow",
+                "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            },
+            "to": {
+                "name": "Bob",
+                "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+            },
+            "contents": "Hello, Bob!"
+        }
+    },
+    "valid_nested_structs": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "Owners": [
+                {
+                    "name": "owners",
+                    "type": "Person[]"
+                }
+            ],
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "contract",
+                    "type": "Contract"
+                }
+            ],
+            "Contract": [
+                {
+                    "name": "address",
+                    "type": "address"
+                },
+                {
+                    "name": "childContracts",
+                    "type": "Contract[]"
+                }
+            ]
+        },
+        "primaryType": "Owners",
+        "domain": {
+            "name": "Contract Owners",
+            "version": "2",
+            "chainId": 1337,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "owners": [
+                {
+                    "name": "Alice",
+                    "contract": {
+                        "address": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        "childContracts": [
+                            {
+                                "address": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                                "childContracts": [
+                                    {
+                                        "address": "0xcccccccccccccccccccccccccccccccccccccccc",
+                                        "childContracts": [
+                                            {
+                                                "address": "0xabababababababababababababababababababab",
+                                                "childContracts": []
+                                            },
+                                            {
+                                                "address": "0xacacacacacacacacacacacacacacacacacacacac",
+                                                "childContracts": []
+                                            },
+                                            {
+                                                "address": "0xadadadadadadadadadadadadadadadadadadadad",
+                                                "childContracts": [
+                                                    {
+                                                        "address": "0xbabababababababababababababababababababa",
+                                                        "childContracts": []
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "address": "0xaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeae",
+                                                "childContracts": []
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "Bob",
+                    "contract": {
+                        "address": "0xfefefefefefefefefefefefefefefefefefefefe",
+                        "childContracts": []
+                    }
+                }
+            ]
+        }
+    },
+    "valid_missing_primary_type_key_and_eip712domain_type": {
+        "types": {
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "wallet",
+                    "type": "address"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "from",
+                    "type": "Person"
+                },
+                {
+                    "name": "to",
+                    "type": "Person"
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                }
+            ]
+        },
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "from": {
+                "name": "Cow",
+                "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            },
+            "to": {
+                "name": "Bob",
+                "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+            },
+            "contents": "Hello, Bob!"
+        }
+    },
+    "valid_issue_201_no_array": {
+        "domain": {
+            "chainId": 1,
+            "name": "Test",
+            "verifyingContract": "0x0000000000000000000000000000000000000000",
+            "version": "1"
+        },
+        "message": {
+            "name": "0xAb8483F64d9C6d1EcF9b849Ae677dD3315835cb2"
+        },
+        "primaryType": "Person",
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "address"
+                }
+            ]
+        }
+    },
+    "valid_multi_array": {
+        "types": {
+            "EIP712Domain": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "version",
+                    "type": "string"
+                },
+                {
+                    "name": "chainId",
+                    "type": "uint256"
+                },
+                {
+                    "name": "verifyingContract",
+                    "type": "address"
+                }
+            ],
+            "Company": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "id",
+                    "type": "uint256"
+                }
+            ],
+            "Person": [
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "company",
+                    "type": "Company"
+                },
+                {
+                    "name": "aliases",
+                    "type": "string[]"
+                },
+                {
+                    "name": "wallet",
+                    "type": "address"
+                }
+            ],
+            "Mail": [
+                {
+                    "name": "ids",
+                    "type": "uint256[]"
+                },
+                {
+                    "name": "from",
+                    "type": "Person"
+                },
+                {
+                    "name": "to",
+                    "type": "Person"
+                },
+                {
+                    "name": "cc",
+                    "type": "Person[]"
+                },
+                {
+                    "name": "bcc",
+                    "type": "Person[][]"
+                },
+                {
+                    "name": "contents",
+                    "type": "string"
+                },
+                {
+                    "name": "tags",
+                    "type": "string[3][4][2]"
+                }
+            ]
+        },
+        "primaryType": "Mail",
+        "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "message": {
+            "ids": [
+                2,
+                3,
+                5,
+                7,
+                11,
+                13,
+                17,
+                19
+            ],
+            "from": {
+                "name": "Cow",
+                "company": {
+                    "name": "farm",
+                    "id": 1
+                },
+                "aliases": [
+                    "Vaca",
+                    "\u041a\u043e\u0440\u043e\u0432\u0430",
+                    "Koe"
+                ],
+                "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            },
+            "to": {
+                "name": "Bob",
+                "company": {
+                    "name": "fishery",
+                    "id": 2
+                },
+                "aliases": [
+                    "Bib",
+                    "Bab"
+                ],
+                "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+            },
+            "cc": [
+                {
+                    "name": "Alice",
+                    "company": {
+                        "name": "theme-park",
+                        "id": 3
+                    },
+                    "aliases": [],
+                    "wallet": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                },
+                {
+                    "name": "Dot",
+                    "company": {
+                        "name": "ice-cream",
+                        "id": 4
+                    },
+                    "aliases": [
+                        "Dash"
+                    ],
+                    "wallet": "0xdddddddddddddddddddddddddddddddddddddddd"
+                }
+            ],
+            "bcc": [
+                [
+                    {
+                        "name": "Earnest",
+                        "company": {
+                            "name": "eatery",
+                            "id": 5
+                        },
+                        "aliases": [],
+                        "wallet": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+                    },
+                    {
+                        "name": "Felicia",
+                        "company": {
+                            "name": "fine dining",
+                            "id": 6
+                        },
+                        "aliases": [
+                            "Fiona"
+                        ],
+                        "wallet": "0xffffffffffffffffffffffffffffffffffffffff"
+                    }
+                ]
+            ],
+            "contents": "Hello, Bob!",
+            "tags": [
+                [
+                    [
+                        "ab",
+                        "cd",
+                        "ss"
+                    ],
+                    [
+                        "ef",
+                        "gh",
+                        "ss"
+                    ],
+                    [
+                        "ij",
+                        "kl",
+                        "ss"
+                    ],
+                    [
+                        "mn",
+                        "op",
+                        "ss"
+                    ]
+                ],
+                [
+                    [
+                        "ch",
+                        "de",
+                        "ss"
+                    ],
+                    [
+                        "gb",
+                        "cn",
+                        "ss"
+                    ],
+                    [
+                        "mx",
+                        "cz",
+                        "ss"
+                    ],
+                    [
+                        "jp",
+                        "co",
+                        "ss"
+                    ]
+                ]
+            ]
+        }
+    }
+}


### PR DESCRIPTION
### What was wrong?

The former `encode_structured_data`, Mask, and even the original EIP expect the message to be a single json object/python dict. 

### How was it fixed?

 - Added the different arg option, plus docs and an example. 
 - Added tests to make sure calling `encode_typed_data` with 3 args provides the same result as with 1 arg
 - Found a bug in handling empty and missing arrays in message, fixed and added tests

### Todo:
- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-account/assets/5199899/3c1d29bb-8474-43f6-beb3-8bc324c07e22)