### PR TITLE
remove deprecated camelCase methods that have a direct snake replacement

### DIFF
--- a/eth_account/signers/base.py
+++ b/eth_account/signers/base.py
@@ -63,23 +63,6 @@ class BaseAccount(ABC):
         pass
 
     @abstractmethod
-    def signTransaction(self, transaction_dict):
-        """
-        Sign a transaction dict.
-
-        This uses the same structure as in
-        :meth:`~eth_account.account.Account.sign_transaction`
-        but without specifying the private key.
-
-        .. CAUTION:: Deprecated for
-            :meth:`~eth_account.account.signers.local.sign_transaction`.
-            This method will be removed in v0.6
-
-        :param dict transaction_dict: transaction with all fields specified
-        """
-        pass
-
-    @abstractmethod
     def sign_transaction(self, transaction_dict):
         """
         Sign a transaction dict.

--- a/eth_account/signers/local.py
+++ b/eth_account/signers/local.py
@@ -1,5 +1,3 @@
-import warnings
-
 from eth_account.signers.base import (
     BaseAccount,
 )
@@ -81,14 +79,6 @@ class LocalAccount(BaseAccount):
         private key argument.
         """
         return self._publicapi.sign_message(signable_message, private_key=self.key)
-
-    def signTransaction(self, transaction_dict):
-        warnings.warn(
-            "signTransaction is deprecated in favor of sign_transaction",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.sign_transaction(transaction_dict)
 
     def sign_transaction(self, transaction_dict):
         return self._publicapi.sign_transaction(transaction_dict, self.key)

--- a/newsfragments/244.removal.rst
+++ b/newsfragments/244.removal.rst
@@ -1,0 +1,1 @@
+Remove deprecated ``signTransaction``, it has been replaced by ``sign_transaction``


### PR DESCRIPTION
### What was wrong?

Several methods that were originally camelCase had direct snake_case replacements. They were deprecated ~5 years ago.

### How was it fixed?

Removed the deprecated camelCase version.

Does not touch the `signHash` -> `sign_message` deprecation, as there's some discussion there sort out.

### Todo:
- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-account/assets/5199899/3da26fd1-96e5-44f8-8910-3fce588b6091)