### PR TITLE
use f-strings in place of old % and .format strings

### DIFF
--- a/eth_account/_utils/legacy_transactions.py
+++ b/eth_account/_utils/legacy_transactions.py
@@ -98,13 +98,14 @@ def assert_valid_fields(transaction_dict):
     # check if any keys are missing
     missing_keys = REQUIRED_TRANSACTION_KEYS.difference(transaction_dict.keys())
     if missing_keys:
-        raise TypeError("Transaction must include these fields: %r" % missing_keys)
+        raise TypeError(f"Transaction must include these fields: {repr(missing_keys)}")
 
     # check if any extra keys were specified
     superfluous_keys = set(transaction_dict.keys()).difference(ALLOWED_TRANSACTION_KEYS)
     if superfluous_keys:
         raise TypeError(
-            "Transaction must not include unrecognized fields: %r" % superfluous_keys
+            "Transaction must not include unrecognized fields: "
+            f"{repr(superfluous_keys)}"
         )
 
     # check for valid types in each field
@@ -118,7 +119,7 @@ def assert_valid_fields(transaction_dict):
             for key, valid in valid_fields.items()
             if not valid
         }
-        raise TypeError("Transaction had invalid fields: %r" % invalid)
+        raise TypeError(f"Transaction had invalid fields: {repr(invalid)}")
 
 
 def chain_id_to_v(transaction_dict):

--- a/eth_account/_utils/signing.py
+++ b/eth_account/_utils/signing.py
@@ -48,7 +48,7 @@ def sign_transaction_dict(eth_key, transaction_dict):
         (v, r, s) = eth_key.sign_msg_hash(transaction_hash).vrs
     else:
         # Cannot happen, but better for code to be defensive + self-documenting.
-        raise TypeError("unknown Transaction object: %s" % type(unsigned_transaction))
+        raise TypeError(f"unknown Transaction object: {type(unsigned_transaction)}")
 
     # serialize transaction with rlp
     encoded_transaction = encode_transaction(unsigned_transaction, vrs=(v, r, s))

--- a/eth_account/_utils/structured_data/hashing.py
+++ b/eth_account/_utils/structured_data/hashing.py
@@ -69,14 +69,11 @@ def field_identifier(field):
     Given a ``field`` of the format {'name': NAME, 'type': TYPE},
     this function converts it to ``TYPE NAME``
     """
-    return "{0} {1}".format(field["type"], field["name"])
+    return f"{field['type']} {field['name']}"
 
 
 def encode_struct(struct_name, struct_field_types):
-    return "{0}({1})".format(
-        struct_name,
-        ",".join(map(field_identifier, struct_field_types)),
-    )
+    return f"{struct_name}({','.join(map(field_identifier, struct_field_types))})"
 
 
 def encode_type(primary_type, types):

--- a/eth_account/_utils/typed_transactions.py
+++ b/eth_account/_utils/typed_transactions.py
@@ -131,10 +131,10 @@ class TypedTransaction:
         """Should not be called directly. Use instead the 'from_dict' method."""
         if not isinstance(transaction, _TypedTransactionImplementation):
             raise TypeError(
-                "expected _TypedTransactionImplementation, got %s" % type(transaction)
+                f"expected _TypedTransactionImplementation, got {type(transaction)}"
             )
         if not isinstance(transaction_type, int):
-            raise TypeError("expected int, got %s" % type(transaction_type))
+            raise TypeError(f"expected int, got {type(transaction_type)}")
         self.transaction_type = transaction_type
         self.transaction = transaction
 
@@ -155,7 +155,7 @@ class TypedTransaction:
         elif transaction_type == DynamicFeeTransaction.transaction_type:
             transaction = DynamicFeeTransaction
         else:
-            raise TypeError("Unknown Transaction type: %s" % transaction_type)
+            raise TypeError(f"Unknown Transaction type: {transaction_type}")
         return cls(
             transaction_type=transaction_type,
             transaction=transaction.from_dict(dictionary),
@@ -165,7 +165,7 @@ class TypedTransaction:
     def from_bytes(cls, encoded_transaction: HexBytes) -> "TypedTransaction":
         """Builds a TypedTransaction from a signed encoded transaction."""
         if not isinstance(encoded_transaction, HexBytes):
-            raise TypeError("expected Hexbytes, got %s" % type(encoded_transaction))
+            raise TypeError(f"expected Hexbytes, got {type(encoded_transaction)}")
         if not (len(encoded_transaction) > 0 and encoded_transaction[0] <= 0x7F):
             raise ValueError("unexpected input")
         transaction: Union["DynamicFeeTransaction", "AccessListTransaction"]
@@ -178,7 +178,7 @@ class TypedTransaction:
         else:
             # The only known transaction types should be explicit if/elif branches.
             raise TypeError(
-                "typed transaction has unknown type: %s" % encoded_transaction[0]
+                f"typed transaction has unknown type: {encoded_transaction[0]}"
             )
         return cls(
             transaction_type=transaction_type,
@@ -294,7 +294,7 @@ class AccessListTransaction(_TypedTransactionImplementation):
             invalid = {
                 key: dictionary[key] for key, valid in valid_fields.items() if not valid
             }
-            raise TypeError("Transaction had invalid fields: %r" % invalid)
+            raise TypeError(f"Transaction had invalid fields: {repr(invalid)}")
 
     @classmethod
     def from_dict(cls, dictionary: Dict[str, Any]) -> "AccessListTransaction":
@@ -316,8 +316,8 @@ class AccessListTransaction(_TypedTransactionImplementation):
         transaction_type = sanitized_dictionary.pop("type")
         if transaction_type != cls.transaction_type:
             raise ValueError(
-                "expected transaction type %s, got %s"
-                % (cls.transaction_type, transaction_type),
+                f"expected transaction type {cls.transaction_type}, "
+                f"got {transaction_type}"
             )
         return cls(
             dictionary=sanitized_dictionary,
@@ -327,9 +327,7 @@ class AccessListTransaction(_TypedTransactionImplementation):
     def from_bytes(cls, encoded_transaction: HexBytes) -> "AccessListTransaction":
         """Builds an AccesslistTransaction from a signed encoded transaction."""
         if not isinstance(encoded_transaction, HexBytes):
-            raise TypeError(
-                "expected Hexbytes, got type: %s" % type(encoded_transaction)
-            )
+            raise TypeError(f"expected Hexbytes, got type: {type(encoded_transaction)}")
         if not (
             len(encoded_transaction) > 0
             and encoded_transaction[0] == cls.transaction_type
@@ -480,7 +478,7 @@ class DynamicFeeTransaction(_TypedTransactionImplementation):
             invalid = {
                 key: dictionary[key] for key, valid in valid_fields.items() if not valid
             }
-            raise TypeError("Transaction had invalid fields: %r" % invalid)
+            raise TypeError(f"Transaction had invalid fields: {repr(invalid)}")
 
     @classmethod
     def from_dict(cls, dictionary: Dict[str, Any]) -> "DynamicFeeTransaction":
@@ -502,8 +500,8 @@ class DynamicFeeTransaction(_TypedTransactionImplementation):
         transaction_type = sanitized_dictionary.pop("type")
         if transaction_type != cls.transaction_type:
             raise ValueError(
-                "expected transaction type %s, got %s"
-                % (cls.transaction_type, transaction_type),
+                f"expected transaction type {cls.transaction_type}, "
+                f"got {transaction_type}"
             )
         return cls(
             dictionary=sanitized_dictionary,
@@ -513,9 +511,7 @@ class DynamicFeeTransaction(_TypedTransactionImplementation):
     def from_bytes(cls, encoded_transaction: HexBytes) -> "DynamicFeeTransaction":
         """Builds a DynamicFeeTransaction from a signed encoded transaction."""
         if not isinstance(encoded_transaction, HexBytes):
-            raise TypeError(
-                "expected Hexbytes, got type: %s" % type(encoded_transaction)
-            )
+            raise TypeError(f"expected Hexbytes, got type: {type(encoded_transaction)}")
         if not (
             len(encoded_transaction) > 0
             and encoded_transaction[0] == cls.transaction_type

--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -743,7 +743,7 @@ class Account:
         """  # noqa: E501
         if not isinstance(transaction_dict, Mapping):
             raise TypeError(
-                "transaction_dict must be dict-like, got %r" % transaction_dict
+                f"transaction_dict must be dict-like, got {repr(transaction_dict)}"
             )
 
         account = self.from_key(private_key)
@@ -754,11 +754,8 @@ class Account:
                 sanitized_transaction = dissoc(transaction_dict, "from")
             else:
                 raise TypeError(
-                    "from field must match key's %s, but it was %s"
-                    % (
-                        account.address,
-                        transaction_dict["from"],
-                    )
+                    f"from field must match key's {account.address}, but it was "
+                    f"{transaction_dict['from']}"
                 )
         else:
             sanitized_transaction = transaction_dict
@@ -802,7 +799,7 @@ class Account:
         except ValidationError as original_exception:
             raise ValueError(
                 "The private key must be exactly 32 bytes long, instead of "
-                "%d bytes." % len(key)
+                f"{len(key)} bytes."
             ) from original_exception
 
     @combomethod

--- a/newsfragments/245.internal.rst
+++ b/newsfragments/245.internal.rst
@@ -1,0 +1,1 @@
+Change older ``%`` and ``.format`` strings to use ``f-strings``

--- a/tests/core/test_accounts.py
+++ b/tests/core/test_accounts.py
@@ -770,7 +770,7 @@ def test_eth_account_encrypt(
         assert encrypted["crypto"]["kdfparams"]["n"] == expected_iterations
     else:
         raise Exception(
-            "test must be upgraded to confirm iterations with kdf %s" % expected_kdf
+            f"test must be upgraded to confirm iterations with kdf {expected_kdf}"
         )
 
     decrypted_key = acct.decrypt(encrypted, password)
@@ -815,7 +815,7 @@ def test_eth_account_prepared_encrypt(
         assert encrypted["crypto"]["kdfparams"]["n"] == expected_iterations
     else:
         raise Exception(
-            "test must be upgraded to confirm iterations with kdf %s" % expected_kdf
+            f"test must be upgraded to confirm iterations with kdf {expected_kdf}"
         )
 
     decrypted_key = acct.decrypt(encrypted, password)


### PR DESCRIPTION
### What was wrong?

Old `%` and `.format` strings still in use.

### How was it fixed?

changed to modern f-strings

### Todo:
- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-account/assets/5199899/21cc193f-50f2-4b3e-8dda-a1d30c8c54df)