### PR TITLE
add sign_typed_data to local signer

### DIFF
--- a/eth_account/account_local_actions.py
+++ b/eth_account/account_local_actions.py
@@ -72,3 +72,15 @@ class AccountLocalActions(ABC):
         blobs: Optional[Blobs] = None,
     ) -> SignedTransaction:
         pass
+
+    @combomethod
+    @abstractmethod
+    def sign_typed_data(
+        self,
+        private_key: PrivateKeyType,
+        domain_data: Optional[Dict[str, Any]] = None,
+        message_types: Optional[Dict[str, Any]] = None,
+        message_data: Optional[Dict[str, Any]] = None,
+        full_message: Optional[Dict[str, Any]] = None,
+    ) -> SignedMessage:
+        pass

--- a/eth_account/signers/local.py
+++ b/eth_account/signers/local.py
@@ -73,6 +73,9 @@ class LocalAccount(BaseAccount):
 
         self._key_obj: PrivateKey = key
 
+    def __bytes__(self) -> bytes:
+        return self.key
+
     @property
     def address(self) -> ChecksumAddress:
         return self._address
@@ -131,5 +134,27 @@ class LocalAccount(BaseAccount):
             self._publicapi.sign_transaction(transaction_dict, self.key, blobs=blobs),
         )
 
-    def __bytes__(self) -> bytes:
-        return self.key
+    def sign_typed_data(
+        self,
+        domain_data: Optional[Dict[str, Any]] = None,
+        message_types: Optional[Dict[str, Any]] = None,
+        message_data: Optional[Dict[str, Any]] = None,
+        full_message: Optional[Dict[str, Any]] = None,
+    ) -> SignedMessage:
+        """
+        Sign the provided EIP-712 message with the local private key.
+
+        This uses the same structure as in
+        :meth:`~eth_account.account.Account.sign_typed_data`, but without a
+        private key argument.
+        """
+        return cast(
+            SignedMessage,
+            self._publicapi.sign_typed_data(
+                private_key=self.key,
+                domain_data=domain_data,
+                message_types=message_types,
+                message_data=message_data,
+                full_message=full_message,
+            ),
+        )

--- a/newsfragments/304.feature.rst
+++ b/newsfragments/304.feature.rst
@@ -1,0 +1,1 @@
+Make ``sign_typed_data`` available in the ``LocalAccount`` class.

--- a/tests/core/test_signers.py
+++ b/tests/core/test_signers.py
@@ -1,0 +1,14 @@
+from eth_account import (
+    Account,
+)
+from tests.eip712_messages import (
+    ALL_VALID_EIP712_MESSAGES,
+)
+
+
+def test_sign_typed_data_signing_same_for_account_and_local_account():
+    new_local_account = Account.create()
+    for message in ALL_VALID_EIP712_MESSAGES.values():
+        assert Account.sign_typed_data(
+            new_local_account.key, full_message=message
+        ) == new_local_account.sign_typed_data(full_message=message)


### PR DESCRIPTION
### What was wrong?

`sign_typed_data` was available in `Account` but not `LocalAccount`.

Closes #304 

### How was it fixed?

Added it!

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/7abfcfdf-7ed4-4b82-9cbb-d96d1cdfeb9f)
