### PR TITLE
Allow normalized to addresses in transactions

### DIFF
--- a/eth_account/_utils/validation.py
+++ b/eth_account/_utils/validation.py
@@ -12,6 +12,7 @@ from eth_utils import (
     is_checksum_address,
     is_dict,
     is_hexstr,
+    is_normalized_address,
 )
 from eth_utils.curried import (
     apply_one_of_formatters,
@@ -58,6 +59,17 @@ def is_empty_or_checksum_address(val: Any) -> bool:
         return True
     else:
         return is_valid_address(val)
+
+
+def is_empty_or_any_address(val: Any) -> bool:
+    if val in VALID_EMPTY_ADDRESSES:
+        return True
+    else:
+        return (
+            is_binary_address(val)
+            or is_checksum_address(val)
+            or is_normalized_address(val)
+        )
 
 
 def is_rpc_structured_access_list(val: Any) -> bool:
@@ -222,7 +234,7 @@ LEGACY_TRANSACTION_VALID_VALUES = {
     "nonce": is_int_or_prefixed_hexstr,
     "gasPrice": is_int_or_prefixed_hexstr,
     "gas": is_int_or_prefixed_hexstr,
-    "to": is_empty_or_checksum_address,
+    "to": is_empty_or_any_address,
     "value": is_int_or_prefixed_hexstr,
     "data": lambda val: isinstance(val, (int, str, bytes, bytearray)),
     "chainId": lambda val: val is None or is_int_or_prefixed_hexstr(val),

--- a/newsfragments/211.bugfix.rst
+++ b/newsfragments/211.bugfix.rst
@@ -1,0 +1,3 @@
+Allowed normalized lowercase ``to`` addresses during transaction signing,
+including addresses with a leading zero nibble that were previously rejected
+as invalid transaction fields.

--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -28,6 +28,7 @@ TEST_PRIVATE_KEY = b"\0" * 31 + b"\x01"
         (dict(GOOD_TXN, to=None), {}),
         (dict(GOOD_TXN, to=b""), {}),
         (dict(GOOD_TXN, to="0x" + "00" * 20), {}),
+        (dict(GOOD_TXN, to="0x0d8ce2a99bb6e3b7db580ed848240e4a0f9ae153"), {}),
         (dict(GOOD_TXN, to="0xF0109fC8DF283027b6285cc889F5aA624EaC1F55"), {}),
         (dict(GOOD_TXN, to="0xf0109Fc8df283027B6285CC889f5Aa624eAc1f55"), {"to"}),
         (dict(GOOD_TXN, to="0x" + "00" * 19), {"to"}),


### PR DESCRIPTION
## Summary
This fixes transaction signing for normalized lowercase `to` addresses, including valid addresses with a leading zero nibble like `0x0d8ce2...` that are currently rejected as invalid transaction fields.

The current validator only accepts binary and checksum addresses for the transaction `to` field. That is stricter than the formatter path, which already knows how to normalize valid hex addresses before encoding.

## What changed
- allow normalized lowercase hex addresses in transaction `to` validation
- keep invalid mixed-case addresses rejected
- add a regression test covering the leading-zero lowercase address form
- add a release note fragment

## Validation
- `pytest tests/core/test_validation.py -q`
- `pre-commit run --files eth_account/_utils/validation.py tests/core/test_validation.py`
- reproduced the original failure on current `main`, then verified the same signing call succeeds after the fix

Closes #211